### PR TITLE
Hotfix for resolving ADC = 0 issues

### DIFF
--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -331,6 +331,7 @@ class DWI(object):
         wcnt, wind = self.createTensorOrder(4)
         ndir = dir.shape[0]
         adc = self.diffusionCoeff(dt[:6], dir)
+        adc[adc == 0] = minZero
         md = np.sum(dt[np.array([0,3,5])], 0)/3
         bW = np.tile(wcnt,(ndir, 1)) * dir[:,wind[:, 0]] * \
              dir[:,wind[:,1]] * dir[:,wind[:, 2]] * dir[:,wind[:, 3]]

--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -11,7 +11,7 @@ import multiprocessing
 from joblib import Parallel, delayed
 from tqdm import tqdm
 import random as rnd
-import warnings
+# import warnings
 
 # Define the lowest number possible before it is considered a zero
 minZero = 1e-8
@@ -20,7 +20,7 @@ minZero = 1e-8
 dirSample = 256
 
 # Suppress warnings because mitigations are applied in code
-warnings.filterwarnings("ignore")
+# warnings.filterwarnings("ignore")
 
 # Progress bar Properties
 tqdmWidth = 70  # Number of columns of progress bar


### PR DESCRIPTION
Closes #39

Defines a precision of `1E-8` when diffusion coefficient is zero to prevent `RuntimeWarning: invalid value encountered in true_divide` warnings. This also produces more accurate kurtosis parameters