### PR TITLE
Add nthreads parameter

### DIFF
--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -11,16 +11,12 @@ import multiprocessing
 from joblib import Parallel, delayed
 from tqdm import tqdm
 import random as rnd
-import warnings
 
 # Define the lowest number possible before it is considered a zero
 minZero = 1e-8
 
 # Define number of directions to resample after computing all tensors
 dirSample = 256
-
-# Suppress warnings because mitigations are applied in code
-warnings.filterwarnings("ignore")
 
 # Progress bar Properties
 tqdmWidth = 70  # Number of columns of progress bar

--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -26,7 +26,7 @@ warnings.filterwarnings("ignore")
 tqdmWidth = 70  # Number of columns of progress bar
 
 class DWI(object):
-    def __init__(self, imPath, num_cores=None):
+    def __init__(self, imPath, num_cores=-1):
         if os.path.exists(imPath):
             assert isinstance(imPath, object)
             self.hdr = nib.load(imPath)

--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -73,12 +73,18 @@ class DWI(object):
             self.workers = -1
         else:
             self.workers = nthreads
-        if self.workers == -2:
-            tqdm.write('Processing with ' + np.str(multiprocessing.cpu_count() - 1) + ' workers...')
+        if self.workers < -1:
+            tqdm.write('Processing with ' +
+                       np.str(multiprocessing.cpu_count() + self.workers + 1)
+                       + ' workers...')
         elif self.workers == -1:
-            tqdm.write('Processing with ' + np.str(multiprocessing.cpu_count()) + ' workers...')
+            tqdm.write('Processing with ' +
+                       np.str(multiprocessing.cpu_count()) +
+                       ' workers...')
         else:
-            tqdm.write('Processing with ' + np.str(self.workers) + ' workers...')
+            tqdm.write('Processing with ' +
+                       np.str(self.workers) +
+                       ' workers...')
 
     def getBvals(self):
         """Returns a vector of b-values, requires no input arguments

--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -62,9 +62,9 @@ class DWI(object):
                    'again')
         tqdm.write('Image ' + fName + '.nii loaded successfully')
         if not isinstance(nthreads, int):
-            assert('Variable nthreads need to be an integer')
+            raise Exception('Variable nthreads need to be an integer')
         if nthreads < -2:
-            assert('Variable nthreads cannot be set below -2')
+            raise Exception('Variable nthreads cannot be set below -2')
         if nthreads is None:
             self.workers = -1
         else:

--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -63,15 +63,14 @@ class DWI(object):
         tqdm.write('Image ' + fName + '.nii loaded successfully')
         if not isinstance(nthreads, int):
             raise Exception('Variable nthreads need to be an integer')
-        if nthreads < -2:
-            raise Exception('Variable nthreads cannot be set below -2')
+        if nthreads < -1 or nthreads == 0:
+            raise Exception('Variable nthreads is a positive integer or '
+                            '-1')
         if nthreads is None:
             self.workers = -1
         else:
             self.workers = nthreads
-        if self.workers < -1:
-            raise Exception('nthreads cannot be set below -1')
-        elif self.workers == -1:
+        if self.workers == -1:
             tqdm.write('Processing with ' +
                        np.str(multiprocessing.cpu_count()) +
                        ' workers...')

--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -26,7 +26,7 @@ warnings.filterwarnings("ignore")
 tqdmWidth = 70  # Number of columns of progress bar
 
 class DWI(object):
-    def __init__(self, imPath, num_cores=-1):
+    def __init__(self, imPath, nthreads=-1):
         if os.path.exists(imPath):
             assert isinstance(imPath, object)
             self.hdr = nib.load(imPath)
@@ -65,14 +65,14 @@ class DWI(object):
             assert('File in path not found. Please locate file and try '
                    'again')
         tqdm.write('Image ' + fName + '.nii loaded successfully')
-        if not isinstance(num_cores, int):
-            assert('Variable num_cores need to be an integer')
-        if num_cores < -2:
-            assert('Variable num_cores cannot be set below -2')
-        if num_cores is None:
+        if not isinstance(nthreads, int):
+            assert('Variable nthreads need to be an integer')
+        if nthreads < -2:
+            assert('Variable nthreads cannot be set below -2')
+        if nthreads is None:
             self.workers = -1
         else:
-            self.workers = num_cores
+            self.workers = nthreads
         if self.workers == -2:
             tqdm.write('Processing with ' + np.str(multiprocessing.cpu_count() - 1) + ' workers...')
         elif self.workers == -1:

--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -70,9 +70,7 @@ class DWI(object):
         else:
             self.workers = nthreads
         if self.workers < -1:
-            tqdm.write('Processing with ' +
-                       np.str(multiprocessing.cpu_count() + self.workers + 1)
-                       + ' workers...')
+            raise Exception('nthreads cannot be set below -1')
         elif self.workers == -1:
             tqdm.write('Processing with ' +
                        np.str(multiprocessing.cpu_count()) +

--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -536,8 +536,6 @@ class DWI(object):
         shat = np.exp(np.matmul(self.b, init))
 
         # dt = np.zeros((22, dwi_.shape[1]))
-        num_cores = multiprocessing.cpu_count()
-
         # for i in inputs:
         #     dt[:,i] = self.wlls(shat[:,i], dwi_[:,i], self.b, cons=C)
         if constraints is None or (constraints[0] == 0 and constraints[1] == 0 and constraints[2] == 0):
@@ -545,7 +543,7 @@ class DWI(object):
                           desc='Unconstrained Tensor Fit',
                           unit='vox',
                           ncols=tqdmWidth)
-            self.dt = Parallel(n_jobs=num_cores, prefer='processes') \
+            self.dt = Parallel(n_jobs=self.workers, prefer='processes') \
                 (delayed(self.wlls)(shat[~reject_[:, i], i], dwi_[~reject_[:, i], i], self.b[~reject_[:, i]]) for i in inputs)
 
         else:
@@ -554,7 +552,7 @@ class DWI(object):
                           desc='Constrained Tensor Fit  ',
                           unit='vox',
                           ncols=tqdmWidth)
-            self.dt = Parallel(n_jobs=num_cores, prefer='processes') \
+            self.dt = Parallel(n_jobs=self.workers, prefer='processes') \
                 (delayed(self.wlls)(shat[~reject_[:, i], i], dwi_[~reject_[:, i], i], self.b[~reject_[:, i]],
                                     cons=C) for i in inputs)
 
@@ -628,7 +626,6 @@ class DWI(object):
         trace:  sum of first eigenvalues
         """
         # extract all tensor parameters from dt
-        num_cores = multiprocessing.cpu_count()
 
         DT = np.reshape(
             np.concatenate((self.dt[0, :], self.dt[1, :], self.dt[2, :],
@@ -650,7 +647,7 @@ class DWI(object):
                       unit='vox',
                       ncols=tqdmWidth)
         values, vectors = zip(
-            *Parallel(n_jobs=num_cores, prefer='processes') \
+            *Parallel(n_jobs=self.workers, prefer='processes') \
                 (delayed(self.dtiTensorParams)(DT[:, :, i]) for i in
                  inputs))
         values = np.reshape(np.abs(values), (nvox, 3))
@@ -692,7 +689,6 @@ class DWI(object):
         fe:     first eigenvectors
         trace:  sum of first eigenvalues
         """
-        num_cores = multiprocessing.cpu_count()
         # get the trace
         rdwi = sigmoid(np.matmul(self.b[:, 1:], self.dt))
         B = np.round(-(self.b[:, 0] + self.b[:, 3] + self.b[:, 5]) * 1000)
@@ -709,7 +705,7 @@ class DWI(object):
                       desc='DKI params              ',
                       unit='vox',
                       ncols=tqdmWidth)
-        ak, rk = zip(*Parallel(n_jobs=num_cores, prefer='processes') \
+        ak, rk = zip(*Parallel(n_jobs=self.workers, prefer='processes') \
             (delayed(self.dkiTensorParams)(self.DTIvectors[i, :, 0],
                                            self.dt[:, i])
              for i in inputs))
@@ -928,9 +924,8 @@ class DWI(object):
         maxB = self.maxBval()
         adc = self.diffusionCoeff(self.dt[:6], self.dirs)
         akc = self.kurtosisCoeff(self.dt, self.dirs)
-        num_cores = multiprocessing.cpu_count()
         inputs = tqdm(range(0, nvox))
-        map = Parallel(n_jobs=num_cores, prefer='processes') \
+        map = Parallel(n_jobs=self.workers, prefer='processes') \
             (delayed(self.findVoxelViol)(adc[:,i], akc[:,i], maxB, [0, 1, 0]) for i in inputs)
         map = np.reshape(pViols2, nvox)
         map = self.multiplyMask(vectorize(map,self.mask))
@@ -1220,8 +1215,7 @@ class DWI(object):
                           desc='IRLLS: Noise Estimation ',
                           unit='vox',
                           ncols=tqdmWidth)
-            num_cores = multiprocessing.cpu_count()
-            sigma_ = Parallel(n_jobs=num_cores, prefer='processes') \
+            sigma_ = Parallel(n_jobs=self.workers, prefer='processes') \
                 (delayed(estSigma)(dwi[:, i], bmat) for i in inputs)
             sigma = np.median(sigma_)
             sigma = np.tile(sigma,(nvox,1))
@@ -1337,7 +1331,7 @@ class DWI(object):
                           desc='IRLLS: Outlier Detection',
                           unit='vox',
                           ncols=tqdmWidth)
-        (reject, dt) = zip(*Parallel(n_jobs=num_cores, prefer='processes') \
+        (reject, dt) = zip(*Parallel(n_jobs=self.workers, prefer='processes') \
             (delayed(outlierHelper)(dwi[:, i], bmat, sigma[i,0], b, b0_pos) for i in inputs))
         # for i in inputs:
         #     reject[:,i], dt[:,i], fa[i], md[i] = outlierHelper(dwi[:, i], bmat, sigma[i,0], b, b0_pos)

--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -65,11 +65,20 @@ class DWI(object):
             assert('File in path not found. Please locate file and try '
                    'again')
         tqdm.write('Image ' + fName + '.nii loaded successfully')
+        if not isinstance(num_cores, int):
+            assert('Variable num_cores need to be an integer')
+        if num_cores < -2:
+            assert('Variable num_cores cannot be set below -2')
         if num_cores is None:
-            self.workers = multiprocessing.cpu_count()
+            self.workers = -1
         else:
             self.workers = num_cores
-        tqdm.write('Processing with ' + np.str(self.workers) + ' workers...')
+        if self.workers == -2:
+            tqdm.write('Processing with ' + np.str(multiprocessing.cpu_count() - 1) + ' workers...')
+        elif self.workers == -1:
+            tqdm.write('Processing with ' + np.str(multiprocessing.cpu_count()) + ' workers...')
+        else:
+            tqdm.write('Processing with ' + np.str(self.workers) + ' workers...')
 
     def getBvals(self):
         """Returns a vector of b-values, requires no input arguments

--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -26,7 +26,7 @@ warnings.filterwarnings("ignore")
 tqdmWidth = 70  # Number of columns of progress bar
 
 class DWI(object):
-    def __init__(self, imPath):
+    def __init__(self, imPath, num_cores=None):
         if os.path.exists(imPath):
             assert isinstance(imPath, object)
             self.hdr = nib.load(imPath)
@@ -65,6 +65,11 @@ class DWI(object):
             assert('File in path not found. Please locate file and try '
                    'again')
         tqdm.write('Image ' + fName + '.nii loaded successfully')
+        if num_cores is None:
+            self.workers = multiprocessing.cpu_count()
+        else:
+            self.workers = num_cores
+        tqdm.write('Processing with ' + np.str(self.workers) + ' workers...')
 
     def getBvals(self):
         """Returns a vector of b-values, requires no input arguments

--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -46,7 +46,7 @@ class DWI(object):
                 # number of DWI volumes. [Gx Gy Gz Bval]
                 self.grad = np.c_[np.transpose(bvecs), bvals]
             else:
-                assert('Unable to locate BVAL or BVEC files')
+                raise NameError('Unable to locate BVAL or BVEC files')
             maskPath = os.path.join(path,'brain_mask.nii')
             if os.path.exists(maskPath):
                 tmp = nib.load(maskPath)


### PR DESCRIPTION
A new parameter for `dwipi.DWI()` has been added that enables allocation of workers for multiprocessing, to close #31. Default is set to process with all available workers to match MRTRIX3's approach. The following excerpt is taken from the [joblib.Parallel](https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html) page and specifies the valid options for this parameter:

> The maximum number of concurrently running jobs, such as the number of Python worker processes when backend=”multiprocessing” or the size of the thread-pool when backend=”threading”. If -1 all CPUs are used. If 1 is given, no parallel computing code is used at all, which is useful for debugging. For n_jobs below -1, (n_cpus + 1 + n_jobs) are used. Thus for n_jobs = -2, all CPUs but one are used. None is a marker for ‘unset’ that will be interpreted as n_jobs=1 (sequential execution) unless the call is performed under a parallel_backend context manager that sets another value for n_jobs.

To use this parameter, simply create a DWI object with `img = dwipi.DWI('path_to_nifti', nthreads=16)` - this will process the DWI object with 16 threads.