### PR TITLE
Hotfix for  situations when ADC is zero

### DIFF
--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -344,6 +344,7 @@ class DWI(object):
         wcnt, wind = self.createTensorOrder(4)
         ndir = dir.shape[0]
         adc = self.diffusionCoeff(dt[:6], dir)
+        adc[adc == 0] = minZero
         md = np.sum(dt[np.array([0,3,5])], 0)/3
         bW = np.tile(wcnt,(ndir, 1)) * dir[:,wind[:, 0]] * \
              dir[:,wind[:,1]] * dir[:,wind[:, 2]] * dir[:,wind[:, 3]]


### PR DESCRIPTION
Sets precision to `1E-8` when `ADC = 0` to prevent `divide_by_zero` warning, and to close #39. This method also refines kurtosis values because it is impossible for diffusion to be zero in the brain.

Said correction is only applied to DKI because it is sensitive to perturbation in diffusion. Applying this to DTI will produce inaccurate maps.