### PR TITLE
Assign correct dims to failed dt fit

### DIFF
--- a/designer/Processing_Example.ipynb
+++ b/designer/Processing_Example.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -530,16 +530,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Median Filtering"
+    "## Running Entire Pipeline"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "python pydesigner.py --denoise --degibbs --undistort --topup /Users/sid/Documents/Projects/IAM/Dataset/NifTi/IAM_1009/18_DKI_BIPOLAR_2_5mm_64dir_50slices_TOP_UP_PA.nii--smooth --rician --verbose /Users/sid/Documents/Projects/IAM/Dataset/NifTi/IAM_1009/17_DKI_BIPOLAR_2_5mm_64dir_50slices.nii -o /Users/sid/Documents/Projects/IAM/Dataset/Processed/IAM_1009\n"
+     ]
+    }
+   ],
    "source": [
-    "goodDirs = myimage.goodDirections(outliers)\n"
+    "inPath = '/Users/sid/Documents/Projects/IAM/Dataset/NifTi/IAM_1009/17_DKI_BIPOLAR_2_5mm_64dir_50slices.nii'\n",
+    "outPath = '/Users/sid/Documents/Projects/IAM/Dataset/Processed/IAM_1009'\n",
+    "topupPath = '/Users/sid/Documents/Projects/IAM/Dataset/NifTi/IAM_1009/18_DKI_BIPOLAR_2_5mm_64dir_50slices_TOP_UP_PA.nii'\n",
+    "cmd = 'python pydesigner.py --denoise --degibbs --undistort --topup ' + \\\n",
+    "topupPath + '--smooth --rician --verbose ' + \\\n",
+    "inPath + ' -o ' + outPath\n",
+    "print(cmd)\n",
+    "os.system(cmd)"
    ]
   },
   {

--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -471,7 +471,7 @@ class DWI(object):
                            max_iter=20000)
                 dt = x.value
             except:
-                dt = np.full((22, ), minZero)
+                dt = np.full_like(x.value, minZero)
         return dt
 
     def fit(self, constraints=None, reject=None, dt_hat=None):


### PR DESCRIPTION
Closes #59 by changing strict assignment of a (22, ) vector of dt fit to a vector which inherits its dimension to that posed in LLS problem. This case only applies when LLS fails to converge to a solution. This issue mainly applies to tensor fitting without brain mask.