### PR TITLE
Support for advanced user

### DIFF
--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -200,6 +200,11 @@ parser.add_argument('--verbose', action='store_true',
                     help='Print out all output. This is a very messy '
                     'option. We recommend piping output to a text file '
                     'if you use this option.')
+parser.add_argument('--adv', action='store_true',
+                    help='Disables safety checks for advanced users who '
+                         'want to force a preprocessing step. Warning: '
+                         'Disabling these checks could yield '
+                         'undersirable results.')
 
 # Use argument specification to actually get args
 args = parser.parse_args()

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -309,10 +309,13 @@ if not filetable['dwi'].isAcquisition():
     raise Exception('Input dwi does not have .bval/.bvec pair')
 
 # Check to make sure no partial fourier if --degibbs given
-if args.degibbs and filetable['dwi'].isPartialFourier():
-    print('Given DWI is partial fourier, overriding --degibbs; '
-          'no unringing correction will be done to avoid artifacts.')
-    args.degibbs = False
+if args.degibbs and args.adv:
+    args.degibbs = True
+else:
+    if args.degibbs and filetable['dwi'].isPartialFourier():
+        print('Given DWI is partial fourier, overriding --degibbs; '
+              'no unringing correction will be done to avoid artifacts.')
+        args.degibbs = False
 
 if args.rpe_pair:
     filetable['rpe_pair'] = DWIFile(args.rpe_pair)

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -202,9 +202,12 @@ parser.add_argument('--verbose', action='store_true',
                     'if you use this option.')
 parser.add_argument('--adv', action='store_true',
                     help='Disables safety checks for advanced users who '
-                         'want to force a preprocessing step. Warning: '
-                         'Disabling these checks could yield '
-                         'undersirable results.')
+                         'want to force a preprocessing step. WARNING: '
+                         'THIS FLAG IS FOR ADVANCED USERS ONLY WHO FULLY '
+                         'UNDERSTAND THE MRI SYSTEM AND ITS OUTPUTS. '
+                         'RUNNING WITH THIS FLAG COULD POTENTIALLY '
+                         'RESULT IN IMPRECISE AND INACCURATE RESULTS, '
+                         'OR A THERMONUCLEAR WAR.')
 
 # Use argument specification to actually get args
 args = parser.parse_args()

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -206,8 +206,7 @@ parser.add_argument('--adv', action='store_true',
                          'THIS FLAG IS FOR ADVANCED USERS ONLY WHO FULLY '
                          'UNDERSTAND THE MRI SYSTEM AND ITS OUTPUTS. '
                          'RUNNING WITH THIS FLAG COULD POTENTIALLY '
-                         'RESULT IN IMPRECISE AND INACCURATE RESULTS, '
-                         'OR A THERMONUCLEAR WAR.')
+                         'RESULT IN IMPRECISE AND INACCURATE RESULTS.')
 
 # Use argument specification to actually get args
 args = parser.parse_args()


### PR DESCRIPTION
Adds an `--adv` flag for advanced users who would like to force a preprocessing step without any safety checks. Currently only implemented for `--degibbs`, but we may expand this to other steps if and when necessary. Fixes #78 