### PR TITLE
B0 series inclusion in concatenation

### DIFF
--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -411,13 +411,13 @@ class DWIParser:
             for i,fname in enumerate(miflist):
                 cat_arg.append(fname)
             cat_arg.append(
-                op.join(path, ('dwi_designer' + '.mif')))
+                op.join(path, ('raw_dwi' + '.mif')))
             cmd = ' '.join(str(e) for e in cat_arg)
             completion = subprocess.run(cmd, shell=True)
             if completion.returncode != 0:
                 raise Exception('Failed to concatenate multiple '
             'series.')
-            miflist.append(op.join(path, 'dwi_designer' + '.mif'))
+            miflist.append(op.join(path, 'raw_dwi' + '.mif'))
             # Output concatenate .mif into .nii
             convert_args = ['mrconvert -stride 1,2,3,4']
             if verbose is False:
@@ -425,12 +425,12 @@ class DWIParser:
             if force is True:
                 convert_args.append('-force')
             convert_args.append('-export_grad_fsl')
-            convert_args.append(op.join(path, 'dwi_designer.bvec'))
-            convert_args.append(op.join(path, 'dwi_designer.bval'))
+            convert_args.append(op.join(path, 'raw_dwi.bvec'))
+            convert_args.append(op.join(path, 'raw_dwi.bval'))
             convert_args.append('-json_export')
-            convert_args.append(op.join(path, 'dwi_designer.json'))
-            convert_args.append(op.join(path, 'dwi_designer.mif'))
-            convert_args.append(op.join(path, 'dwi_designer' + ext))
+            convert_args.append(op.join(path, 'raw_dwi.json'))
+            convert_args.append(op.join(path, 'raw_dwi.mif'))
+            convert_args.append(op.join(path, 'raw_dwi' + ext))
             cmd = ' '.join(str(e) for e in convert_args)
             completion = subprocess.run(cmd, shell=True)
             if completion.returncode != 0:

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -434,7 +434,13 @@ class DWIParser:
             cmd = ' '.join(str(e) for e in convert_args)
             completion = subprocess.run(cmd, shell=True)
             if completion.returncode != 0:
-                raise Exception('Conversion to ' + ext + ' failed.')
+                raise Exception('Conversion to ' + ext + ' failed. Please '
+                                'ensure that your input NifTi files have '
+                                'the same phase encoding directions, and '
+                                'are accompanied by valid .bval, .bvec, '
+                                'and .json. If this is not possible, '
+                                'please provide manually concatenated '
+                                'DWIs or run with single series input.')
             for i, fname in enumerate(miflist):
                 os.remove(fname)
     def getPath(self):
@@ -456,6 +462,11 @@ class DWIParser:
             Path to NifTi file
         """
         image = DWIFile(path)
+        if not image.hasJSON():
+            raise Exception('It is not advisable to run multi-series '
+                            'processing without `.json` files. Please '
+                            'ensure your NifTi files come with .json '
+                            'files.')
         args_info = ['mrinfo', path]
         cmd = ' '.join(str(e) for e in args_info)
         # Reads the "Dimension line of `mrinfo` and extracts the size

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -434,10 +434,13 @@ class DWIParser:
             cmd = ' '.join(str(e) for e in convert_args)
             completion = subprocess.run(cmd, shell=True)
             if completion.returncode != 0:
-                raise Exception('Conversion to ' + ext + ' failed. Please '
-                                'ensure that your input NifTi files have '
-                                'the same phase encoding directions, and '
-                                'are accompanied by valid .bval, .bvec, '
+                for i, fname in enumerate(miflist):
+                    os.remove(fname)
+                os.remove(op.join(path, 'raw_dwi' + ext))
+                raise Exception('Concatenation to ' + str(ext) + 'failed. '
+                                'Please ensure that your input NifTi files '
+                                'have the same phase encoding directions, '
+                                'and are accompanied by valid .bval, .bvec, '
                                 'and .json. If this is not possible, '
                                 'please provide manually concatenated '
                                 'DWIs or run with single series input.')

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -357,6 +357,8 @@ class DWIParser:
     def cat(self, path, ext='.nii' ,verbose=False, force=False):
         """Concatenates all input series when nDWI > 1 into a 4D NifTi
         along with a appropriate BVAL, BVEC and JSON files.
+        Concatenation of series via MRTRIX3 requires every NifTi file to
+        come with BVAL/BVEC to produce a .json with `dw_scheme`.
 
         Parameters
         ----------

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -491,7 +491,3 @@ class DWIParser:
             np.savetxt((fPath + '.bvec'), bvec, delimiter=' ', fmt='%d')
             np.savetxt((fPath + '.bval'), np.c_[bval], delimiter=' ',
                        fmt='%d')
-
-
-
-

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -455,7 +455,6 @@ class DWIParser:
         path:   string
             Path to NifTi file
         """
-        print(path)
         image = DWIFile(path)
         args_info = ['mrinfo', path]
         cmd = ' '.join(str(e) for e in args_info)
@@ -465,7 +464,6 @@ class DWIParser:
                                 stdout=subprocess.PIPE)
         strlist = pipe.stdout.readlines()[3].split()
         dims = [int(i) for i in strlist if i.isdigit()]
-        print(dims)
         nDWI = dims[-1]
         # Check whether for inexistence of gradient table in JSON and
         # some mention of B0 in EPI

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -224,7 +224,7 @@ if image.nDWI > 1:
     image.cat(path=outpath,
               verbose=args.verbose,
               force=args.force)
-    args.dwi = op.join(outpath, 'dwi_designer.nii')
+    args.dwi = op.join(outpath, 'raw_dwi.nii')
 
 #---------------------------------------------------------------------
 # Validate Arguments


### PR DESCRIPTION
In the conversion from DICOM to NifTi, `dcm2niix` does not output FSL gradient tables for B0 series (not the case for interleaved B0s). Later, when this NifTi is converted to .mif with `mrconvert`, the lack of a gradient table leads to the absence of `dw_scheme` from .mif header. If any series in the concatenation of multiple series has a missing `dw_scheme`, `mrcat` will remove said field from the concatenate file's header, leading to complete loss of gradient information.

This fix watches out for B0 series before converting or concatenating them by looking for 'b0' or 'B0' keywords in a series' `SeriesDescription` and `ProtocolName` .json fields. If these exist, it will create a BVEC/BVAL pair prior to converting them to .mif. This ensures that every 3D volume across multiple series is accounted for in terms of gradient tables, leading to perfect concatenation and preservation of `dw_scheme`.

Tested with two different datasets with variations between combination of series. Fix seems stable and works very well. NifTi file handling at this point is vastly superior to original [DKI-Designer](https://github.com/m-ama/DKI-Designer). 

NOTES: 
1. This does not work with TOPUP series because of different phase-encoding directions. Researchers need to understand that series can be concatenated if and only if they have the same phase encoding directions. This point is only applicable if inputs are NifTi files.

2. Dicoms inputs are handled differently and MRTRIX is able to preserve header information across all series correctly, even if they have different phase-encoding information. This is why we'll be adding Dicom support in `0.2-dev`.

EDIT:
Expanded reason why concatenation fails and how to overcome. Now also removes intermediate files if concatenation fails.