### PR TITLE
Fix instances where signal magnitude is less than zero

### DIFF
--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -29,9 +29,9 @@ class DWI(object):
             assert isinstance(imPath, object)
             self.hdr = nib.load(imPath)
             self.img = np.array(self.hdr.dataobj)
-            zeroIdx = np.logical_and(np.isnan(self.img),
+            truncateIdx = np.logical_and(np.isnan(self.img),
                                     (self.img < minZero))
-            self.img[zeroIdx] = minZero
+            self.img[truncateIdx] = minZero
             # Get just NIFTI filename + extensio
             (path, file) = os.path.split(imPath)
             # Remove extension from NIFTI filename

--- a/designer/fitting/dwipi.py
+++ b/designer/fitting/dwipi.py
@@ -29,8 +29,9 @@ class DWI(object):
             assert isinstance(imPath, object)
             self.hdr = nib.load(imPath)
             self.img = np.array(self.hdr.dataobj)
-            nanidx = np.isnan(self.img)
-            self.img[nanidx] = minZero
+            zeroIdx = np.logical_and(np.isnan(self.img),
+                                    (self.img < minZero))
+            self.img[zeroIdx] = minZero
             # Get just NIFTI filename + extensio
             (path, file) = os.path.split(imPath)
             # Remove extension from NIFTI filename


### PR DESCRIPTION
This PR introduces a simple fix that fixes signal magnitude less than zero. Non-positive signal introduces computation errors and warnings in IRWLLS and WLLS, especially with bad dataset. This fix takes care of 500 or so warnings that appear with some datasets.