### PR TITLE
Enable saving of AKC outlier map

### DIFF
--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -710,6 +710,8 @@ if not args.nofit:
                 # do akc
                 akc_out = img.akcoutliers()
                 img.akccorrect(akc_out)
+                dp.writeNii(akcout, img.hdr,
+                            op.join(metricpath, 'outliers_akc'))
             mk, rk, ak, kfa, mkt, trace = img.extractDKI()
             # naive implementation of writing these variables
             dp.writeNii(mk, img.hdr, op.join(metricpath, 'mk'))

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -710,8 +710,8 @@ if not args.nofit:
                 # do akc
                 akc_out = img.akcoutliers()
                 img.akccorrect(akc_out)
-                dp.writeNii(akcout, img.hdr,
-                            op.join(metricpath, 'outliers_akc'))
+                dp.writeNii(akc_out, img.hdr,
+                            op.join(fitqcpath, 'outliers_akc'))
             mk, rk, ak, kfa, mkt, trace = img.extractDKI()
             # naive implementation of writing these variables
             dp.writeNii(mk, img.hdr, op.join(metricpath, 'mk'))

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -688,7 +688,7 @@ if not args.nofit:
         if not args.nooutliers:
             outliers, dt_est = img.irlls()
             # write outliers to qc folder
-            outlier_full = op.join(fitqcpath, 'Outliers_IRLLS.nii')
+            outlier_full = op.join(fitqcpath, 'outliers_irlls.nii')
             dp.writeNii(outliers, img.hdr, outlier_full)
             # fit while rejecting outliers
             img.fit(fit_constraints, reject=outliers, dt_hat=dt_est)


### PR DESCRIPTION
Allows AKC outlier maps to be saved into `mterics_qc` folder. Simple PR.