### PR TITLE
Pushes eddyqc things into metrics_qc dir

### DIFF
--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -449,7 +449,7 @@ if args.undistort:
     # Add to HEAD name
     undistorted_name = 'u' + filetable['HEAD'].getName() + '.nii'
     undistorted_full = op.join(outpath, undistorted_name)
-    eddyqc = op.join(outpath, 'EDDYQC')
+    eddyqc = op.join(outpath, 'metric_qc', 'EDDYQC')
     if op.exists(eddyqc):
         if args.force:
             shutil.rmtree(eddyqc)

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -449,7 +449,7 @@ if args.undistort:
     # Add to HEAD name
     undistorted_name = 'u' + filetable['HEAD'].getName() + '.nii'
     undistorted_full = op.join(outpath, undistorted_name)
-    eddyqc = op.join(outpath, 'metric_qc', 'EDDYQC')
+    eddyqc = op.join(outpath, 'metric_qc', 'eddyqc')
     if op.exists(eddyqc):
         if args.force:
             shutil.rmtree(eddyqc)

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -656,7 +656,7 @@ filetable['HEAD'] = filetable['preprocessed']
 if not args.nofit:
     # make metric map directory
     metricpath = op.join(outpath, 'metrics')
-    fitqcpath = op.join(outpath, 'metrics_qc')
+    fitqcpath = op.join(outpath, 'metrics_qc', 'fitting')
     if op.exists(metricpath):
         if args.force:
             shutil.rmtree(metricpath)
@@ -665,7 +665,7 @@ if not args.nofit:
                             'In order to run this please delete the '
                             'files, use --force, use --resume, or '
                             'change output destination.')
-    if op.exists(fitqcpath) and not args.undistort:
+    if op.exists(fitqcpath):
         if args.force:
             shutil.rmtree(fitqcpath)
         else:

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -449,7 +449,7 @@ if args.undistort:
     # Add to HEAD name
     undistorted_name = 'u' + filetable['HEAD'].getName() + '.nii'
     undistorted_full = op.join(outpath, undistorted_name)
-    eddyqc = op.join(outpath, 'metric_qc', 'eddyqc')
+    eddyqc = op.join(outpath, 'metrics_qc', 'eddyqc')
     if op.exists(eddyqc):
         if args.force:
             shutil.rmtree(eddyqc)
@@ -656,7 +656,7 @@ filetable['HEAD'] = filetable['preprocessed']
 if not args.nofit:
     # make metric map directory
     metricpath = op.join(outpath, 'metrics')
-    fitqcpath = op.join(outpath, 'metric_qc')
+    fitqcpath = op.join(outpath, 'metrics_qc')
     if op.exists(metricpath):
         if args.force:
             shutil.rmtree(metricpath)

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -656,7 +656,7 @@ filetable['HEAD'] = filetable['preprocessed']
 if not args.nofit:
     # make metric map directory
     metricpath = op.join(outpath, 'metrics')
-    fitqcpath = op.join(outpath, 'metrics_qc', 'fitting')
+    fitqcpath = op.join(outpath, 'metrics_qc')
     if op.exists(metricpath):
         if args.force:
             shutil.rmtree(metricpath)
@@ -665,7 +665,7 @@ if not args.nofit:
                             'In order to run this please delete the '
                             'files, use --force, use --resume, or '
                             'change output destination.')
-    if op.exists(fitqcpath):
+    if op.exists(fitqcpath) and not args.undistort:
         if args.force:
             shutil.rmtree(fitqcpath)
         else:

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -656,7 +656,7 @@ filetable['HEAD'] = filetable['preprocessed']
 if not args.nofit:
     # make metric map directory
     metricpath = op.join(outpath, 'metrics')
-    fitqcpath = op.join(outpath, 'metrics_qc')
+    fitqcpath = op.join(outpath, 'metrics_qc', 'fitting')
     if op.exists(metricpath):
         if args.force:
             shutil.rmtree(metricpath)


### PR DESCRIPTION
Organizes all QC metrics into the QC dir to keep output directory organized. There are two main QC dirs - 1) `metrics_qc/eddyqc` and 2) `metrics_qc/fitting` for the two stages where QC things are generated.