### PR TITLE
Bugfix for IRLLS failing

### DIFF
--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -1483,6 +1483,9 @@ class DWI(object):
                     GMM = np.square(C) / np.square(np.square(residu) + \
                                                    np.square(C))
                 except:
+                    # The following line produces a lot of Intel MKL
+                    # warnings that should be ignored. This is a known
+                    # Intel and Numpy bug that has not yet been resolved.
                     GMM = np.full(C.shape, minZero)
                 w = np.sqrt(GMM) * dwi_hat
                 dt_imin1 = dt_i

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -1313,7 +1313,6 @@ class DWI(object):
                     that are outliers
         dt:         IRLLS method of DT estimation
         """
-
         # if not excludeb0.dtype:
         #     assert('option: Excludeb0 should be set to True or False')
 
@@ -1432,7 +1431,6 @@ class DWI(object):
             dwi_i = dwi_i[~out.reshape(-1)]
             n_i = dwi_i.size
             ndof_i = n_i - bmat_i.shape[1]
-
             # WLLS estimation
             # dt_i = np.linalg.lstsq(bmat_i, np.log(dwi_i), rcond=None)[0]
             try:

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -1528,7 +1528,7 @@ class DWI(object):
                     upperbound_nonlinear = np.full(lev.shape, minZero)
                 tmp = np.zeros(residu.shape, dtype=bool, order='F')
                 tmp[residu < lowerbound_linear] = True
-                tmp[residu > lowerbound_linear] = True
+                tmp[residu > upperbound_nonlinear] = True
                 tmp[lev > leverage] = False
                 tmp2 = np.ones(b.shape, dtype=bool, order='F')
                 tmp2[~out.reshape(-1)] = tmp

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -547,7 +547,7 @@ class DWI(object):
         -------
         self.dt:    return diffusion tensor within DWI class
         """
-        # Create constraints
+        # Handle rejected voxels from IRLLS
         if reject is None:
             reject = np.zeros(self.img.shape)
         grad = self.grad

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -1579,6 +1579,7 @@ class DWI(object):
             #      np.sqrt(np.square(eigv[0]) + np.square(eigv[1]) + np.square(eigv[2])))
             # md = np.sum(eigv)/3
             return reject.reshape(-1), dt.reshape(-1)#, fa, md
+        np.seterr(invalid='raise', divide='raise')
         inputs = tqdm(range(nvox),
                           desc='IRLLS: Outlier Detection',
                           unit='vox',
@@ -1587,6 +1588,7 @@ class DWI(object):
             (delayed(outlierHelper)(dwi[:, i], bmat, sigma[i,0], b, b0_pos) for i in inputs))
         # for i in inputs:
         #     reject[:,i], dt[:,i] = outlierHelper(dwi[:, i], bmat, sigma[i,0], b, b0_pos)
+        np.seterr(**defaultErrorState)
         dt = np.array(dt)
         # self.dt = dt
         #Unscaling

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -1371,9 +1371,9 @@ class DWI(object):
             def estSigma(dwi, bmat):
                 dwi = np.reshape(dwi, (len(dwi), 1))
                 try:
-                    dt_ = np.linalg.lstsq(bmat, np.log(dwi), rcond=None)[0]
-                    # dt_ = np.linalg.solve(np.dot(bmat.T, bmat), np.dot(
-                    #     bmat.T, np.log(dwi)))
+                    # dt_ = np.linalg.lstsq(bmat, np.log(dwi), rcond=None)[0]
+                    dt_ = np.linalg.solve(np.dot(bmat.T, bmat), np.dot(
+                        bmat.T, np.log(dwi)))
                 except:
                     dt_ = np.full((bmat.shape[1], 1), minZero)
                 w = np.exp(np.matmul(bmat, dt_)).reshape((ndwi, 1))
@@ -1419,24 +1419,25 @@ class DWI(object):
             n_i = dwi_i.size
             ndof_i = n_i - bmat_i.shape[1]
             # WLLS estimation
-            # dt_i = np.linalg.lstsq(bmat_i, np.log(dwi_i), rcond=None)[0]
+
             try:
-                dt_i = np.linalg.solve(np.dot(bmat_i.T, bmat_i),
-                                       np.dot(bmat_i.T, np.log(dwi_i)))
+                dt_i = np.linalg.lstsq(bmat_i, np.log(dwi_i), rcond=None)[0]
+                # dt_i = np.linalg.solve(np.dot(bmat_i.T, bmat_i),
+                #                        np.dot(bmat_i.T, np.log(dwi_i)))
             except:
                 dt_i = np.full((bmat_i.shape[1], 1), minZero)
             w = np.exp(np.matmul(bmat_i, dt_i))
-            # dt_i = np.linalg.lstsq((bmat_i * np.tile(w, (1, nparam))),
-            #                        (np.log(dwi_i).reshape(
-            #                            (dwi_i.shape[0], 1)) * w),
-            #                        rcond=None)[0]
             try:
-                dt_i = np.linalg.solve(
-                    np.dot((bmat_i * np.tile(w, (1, nparam))).T,
-                           (bmat_i * np.tile(w, (1, nparam)))),
-                    np.dot((bmat_i * np.tile(w, (1, nparam))).T,
-                           (np.log(dwi_i).reshape(
-                               (dwi_i.shape[0], 1)) * w)))
+                dt_i = np.linalg.lstsq((bmat_i * np.tile(w, (1, nparam))),
+                                       (np.log(dwi_i).reshape(
+                                           (dwi_i.shape[0], 1)) * w),
+                                       rcond=None)[0]
+                # dt_i = np.linalg.solve(
+                #     np.dot((bmat_i * np.tile(w, (1, nparam))).T,
+                #            (bmat_i * np.tile(w, (1, nparam)))),
+                #     np.dot((bmat_i * np.tile(w, (1, nparam))).T,
+                #            (np.log(dwi_i).reshape(
+                #                (dwi_i.shape[0], 1)) * w)))
             except:
                 dt_i = np.full((bmat_i.shape[1], 1), minZero)
             dwi_hat = np.exp(np.matmul(bmat_i, dt_i))

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -1371,9 +1371,9 @@ class DWI(object):
             def estSigma(dwi, bmat):
                 dwi = np.reshape(dwi, (len(dwi), 1))
                 try:
-                    # dt_ = np.linalg.lstsq(bmat, np.log(dwi), rcond=None)[0]
-                    dt_ = np.linalg.solve(np.dot(bmat.T, bmat), np.dot(
-                        bmat.T, np.log(dwi)))
+                    dt_ = np.linalg.lstsq(bmat, np.log(dwi), rcond=None)[0]
+                    # dt_ = np.linalg.solve(np.dot(bmat.T, bmat), np.dot(
+                    #     bmat.T, np.log(dwi)))
                 except:
                     dt_ = np.full((bmat.shape[1], 1), minZero)
                 w = np.exp(np.matmul(bmat, dt_)).reshape((ndwi, 1))

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -44,7 +44,7 @@ class DWI(object):
                 # Load bvecs
                 bvecs = np.loadtxt(bvecPath)
                 # Load bvals
-                bvals = np.rint(np.loadtxt(bvalPath)) / 1000
+                bvals = np.rint(np.loadtxt(bvalPath) / 1000)
                 # Combine bvecs and bvals into [n x 4] array where n is
                 # number of DWI volumes. [Gx Gy Gz Bval]
                 self.grad = np.c_[np.transpose(bvecs), bvals]

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -1384,21 +1384,21 @@ class DWI(object):
         except NameError:
             def estSigma(dwi, bmat):
                 dwi = np.reshape(dwi, (len(dwi), 1))
-                # dt_ = np.linalg.lstsq(bmat, np.log(dwi), rcond=None)[0]
                 try:
-                    dt_ = np.linalg.solve(np.dot(bmat.T, bmat), np.dot(
-                        bmat.T, np.log(dwi)))
+                    dt_ = np.linalg.lstsq(bmat, np.log(dwi), rcond=None)[0]
+                    # dt_ = np.linalg.solve(np.dot(bmat.T, bmat), np.dot(
+                    #     bmat.T, np.log(dwi)))
                 except:
                     dt_ = np.full((bmat.shape[1], 1), minZero)
                 w = np.exp(np.matmul(bmat, dt_)).reshape((ndwi, 1))
-                # dt_ = np.linalg.lstsq((bmat * np.tile(w, (1, nparam))),
-                #                       (np.log(dwi) * w), rcond=None)[0]
                 try:
-                    dt_ = np.linalg.solve(
-                        np.dot((bmat * np.tile(w, (1, nparam))).T,
-                            (bmat * np.tile(w, (1, nparam)))), \
-                        np.dot((bmat * np.tile(w, (1, nparam))).T, (np.log(
-                            dwi) * w)))
+                    dt_ = np.linalg.lstsq((bmat * np.tile(w, (1, nparam))),
+                                          (np.log(dwi) * w), rcond=None)[0]
+                    # dt_ = np.linalg.solve(
+                    #     np.dot((bmat * np.tile(w, (1, nparam))).T,
+                    #         (bmat * np.tile(w, (1, nparam)))), \
+                    #     np.dot((bmat * np.tile(w, (1, nparam))).T, (np.log(
+                    #         dwi) * w)))
                 except:
                     dt_ = np.full((bmat.shape[1], 1), minZero)
                 e = np.log(dwi) - np.matmul(bmat, dt_)
@@ -1488,17 +1488,17 @@ class DWI(object):
                     GMM = np.full(C.shape, minZero)
                 w = np.sqrt(GMM) * dwi_hat
                 dt_imin1 = dt_i
-                # dt_i = np.linalg.lstsq(
-                #     (bmat_i * np.tile(w, (1, nparam))),
-                #     (np.log(dwi_i).reshape((dwi_i.shape[0], 1)) * w),
-                #                        rcond=None)[0]
                 try:
-                    dt_i = np.linalg.solve(
-                        np.dot((bmat_i * np.tile(w, (1, nparam))).T,
-                               (bmat_i * np.tile(w, (1, nparam)))),
-                        np.dot((bmat_i * np.tile(w, (1, nparam))).T,
-                               (np.log(dwi_i).reshape(
-                                   (dwi_i.shape[0], 1)) * w)))
+                    dt_i = np.linalg.lstsq(
+                        (bmat_i * np.tile(w, (1, nparam))),
+                        (np.log(dwi_i).reshape((dwi_i.shape[0], 1)) * w),
+                                           rcond=None)[0]
+                    # dt_i = np.linalg.solve(
+                    #     np.dot((bmat_i * np.tile(w, (1, nparam))).T,
+                    #            (bmat_i * np.tile(w, (1, nparam)))),
+                    #     np.dot((bmat_i * np.tile(w, (1, nparam))).T,
+                    #            (np.log(dwi_i).reshape(
+                    #                (dwi_i.shape[0], 1)) * w)))
                 except:
                     dt_i = np.full((bmat_i.shape[1], 1), minZero)
                 dwi_hat = np.exp(np.matmul(bmat_i, dt_i))
@@ -1553,20 +1553,20 @@ class DWI(object):
             keep = ~reject.reshape(-1)
             bmat_i = bmat[keep,:]
             dwi_i = dwi[keep]
-            # dt_ = np.linalg.lstsq(bmat_i, np.log(dwi_i), rcond=None)[0]
             try:
-                dt_ = np.linalg.solve(np.dot(bmat_i.T, bmat_i), \
-                                    np.dot(bmat_i.T, np.log(dwi_i)))
+                dt_ = np.linalg.lstsq(bmat_i, np.log(dwi_i), rcond=None)[0]
+                # dt_ = np.linalg.solve(np.dot(bmat_i.T, bmat_i), \
+                #                     np.dot(bmat_i.T, np.log(dwi_i)))
             except:
                 dt_ = np.full((bmat_i.shape[1], 1), minZero)
             w = np.exp(np.matmul(bmat_i, dt_))
-            # dt = np.linalg.lstsq((bmat_i * np.tile(w.reshape((len(w),1)), (1, nparam))), (np.log(dwi_i).reshape((dwi_i.shape[0], 1)) * w.reshape((len(w),1))),
-            #                            rcond=None)[0]
             try:
-                dt = np.linalg.solve(\
-                    np.dot((bmat_i * np.tile(w.reshape((len(w),1)), (1, nparam))).T, (bmat_i * np.tile(w.reshape((len(w),1)), (1, nparam)))), \
-                    np.dot((bmat_i * np.tile(w.reshape((len(w),1)), (1, nparam))).T, \
-                        (np.log(dwi_i).reshape((dwi_i.shape[0], 1)) * w.reshape((len(w),1)))))
+                dt = np.linalg.lstsq((bmat_i * np.tile(w.reshape((len(w),1)), (1, nparam))), (np.log(dwi_i).reshape((dwi_i.shape[0], 1)) * w.reshape((len(w),1))),
+                                           rcond=None)[0]
+                # dt = np.linalg.solve(\
+                #     np.dot((bmat_i * np.tile(w.reshape((len(w),1)), (1, nparam))).T, (bmat_i * np.tile(w.reshape((len(w),1)), (1, nparam)))), \
+                #     np.dot((bmat_i * np.tile(w.reshape((len(w),1)), (1, nparam))).T, \
+                #         (np.log(dwi_i).reshape((dwi_i.shape[0], 1)) * w.reshape((len(w),1)))))
             except:
                 dt = np.full((bmat_i.shape[1], 1), minZero)
             # dt_tmp = dt.reshape(-1)

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -675,10 +675,12 @@ if not args.nofit:
                             'files, use --force, use --resume, or '
                             'change output destination.')
 
+    if not args. resume and (not args.undistort and not args.nooutlier):
+        os.mkdir(qcpath)
+
     if not args.resume and (not
     (op.exists(metricpath) and op.exists(fitqcpath))):
         os.mkdir(metricpath)
-        os.mkdir(qcpath)
         os.mkdir(fitqcpath)
 
         # create dwi fitting object

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -696,7 +696,7 @@ if not args.nofit:
             outlier_full = op.join(fitqcpath, 'outliers_irlls.nii')
             dp.writeNii(outliers, img.hdr, outlier_full)
             # fit while rejecting outliers
-            img.fit(fit_constraints, reject=outliers, dt_hat=dt_est)
+            img.fit(fit_constraints, reject=outliers)
         else:
             # fit without rejecting outliers
             img.fit(fit_constraints)

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -688,7 +688,10 @@ if not args.nofit:
             img = dp.DWI(filetable['HEAD'].getFull(), args.nthreads)
         # detect outliers
         if not args.nooutliers:
-            outliers, dt_est = img.irlls()
+            if not img.isdki():
+                outliers, dt_est = img.irlls(mode='DTI')
+            else:
+                outliers, dt_est = img.irlls(mode='DKI')
             # write outliers to qc folder
             outlier_full = op.join(fitqcpath, 'outliers_irlls.nii')
             dp.writeNii(outliers, img.hdr, outlier_full)


### PR DESCRIPTION
This PR fixes instances where a convergence failure would result in IRLLS producing an error. This fix affect DTI more than DKI in based on my observation. The following fixes have been implemented:

1. Better LLS algorithm that converges more frequently
2. Error and warning handling
3. Defining correctly sized matrices in case of convergence failure
4. Disabled tensor estimation with warm start. This isn't required and just adds memory overhead for no reason while introducing heaps of problems.

Previously, virtually every DTI 2D slice would be marked as an outlier. This isn't the case anymore. DTI volumes are now correctly evaluated for outliers, just like their DKI counterparts. There is also a non-significant speed boost.