### PR TITLE
DICOM support and .mif switching in DWIParser

### DIFF
--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -119,6 +119,36 @@ def find_valid_ext(pathname):
     
     return exts
 
+def imagetype(path):
+    """
+    Checks input file type
+
+    Parameters
+    ----------
+    path:   string
+        Directory or file path to inquire
+
+    Returns
+    -------
+    String containing filetype
+    """
+    cmd = ['mrinfo', '-quiet']
+    cmd.append(path)
+    completion = subprocess.run(cmd, stdout=subprocess.PIPE)
+    if completion.returncode != 0:
+        raise IOError('Input {} is not currently supported by '
+                                 'PyDesigner.'.format(path))
+    console = str(completion.stdout).split('\\n')
+    matched_indexes = []
+    i = 0
+    while i < len(console):
+        if 'Format' in console[i]:
+            matched_indexes.append(i)
+        i += 1
+    fstring = console[matched_indexes[0]].split()[1]
+    ftype = ''.join(filter(str.isalpha, fstring)).lower()
+    return ftype
+
 class DWIFile:
     """
     Diffusion data file object, used for handling paths and extensions.

--- a/docker/Dockerfile_latest
+++ b/docker/Dockerfile_latest
@@ -102,7 +102,7 @@ ENV PATH=$PATH:/usr/lib/mrtrix3/bin
 
 # Remove unwanted packages
 RUN apt-get autoremove && apt-get clean
-RUN rm -r /tmp
+RUN rm /tmp/fslinstaller.py
 
 # Set image props
 WORKDIR /usr/local/PyDesigner/designer

--- a/docker/Dockerfile_release
+++ b/docker/Dockerfile_release
@@ -102,7 +102,7 @@ ENV PATH=$PATH:/usr/lib/mrtrix3/bin
 
 # Remove unwanted packages
 RUN apt-get autoremove && apt-get clean
-RUN rm -r /tmp
+RUN rm /tmp/fslinstaller.py && rm /tmp/Installer_PyDesigner.sh
 
 # Set image props
 WORKDIR /usr/local/PyDesigner/designer


### PR DESCRIPTION
This PR closes #33, closes #34, closes #118, by adding dicom support. DWIParser class can will now take in a sorted dicom folder and convert it to _.nii_, or as prescribed by `ext` variable in `DWIParser.cat()`. Setting `ext='.mif'` at a later time will allow `.mif` support.