### PR TITLE
DICOM support and .mif switching in DWIParser

### DIFF
--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -387,6 +387,10 @@ class DWIParser:
                             'Please input either input types exclusively.')
 
         DWIflist = [op.splitext(i) for i in self.DWIlist]
+        if '.gz' in np.unique(np.array(DWIflist)[:,-1])[0]:
+            for idx, i in enumerate(DWIflist):
+                DWIflist[idx] = (op.splitext(i[0])[0], '.nii.gz')
+
         self.DWInlist = [i[0] for i in DWIflist]
         self.BVALlist = [i + '.bval' for i in self.DWInlist]
         self.BVEClist = [i + '.bvec' for i in self.DWInlist]

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -140,11 +140,15 @@ def imagetype(path):
                                  'PyDesigner.'.format(path))
     console = str(completion.stdout).split('\\n')
     matched_indexes = []
+    # This loop iterates across the console output to find the line
+    # containing the string 'Format'.
     i = 0
     while i < len(console):
         if 'Format' in console[i]:
             matched_indexes.append(i)
         i += 1
+    # Indexed line is split and alphabets from the second element are
+    # extracted, which determines the input type.
     fstring = console[matched_indexes[0]].split()[1]
     ftype = ''.join(filter(str.isalpha, fstring)).lower()
     return ftype
@@ -416,11 +420,8 @@ class DWIParser:
         force:      bool
             Forces file overwrite if they already exist
         """
-        # if self.nDWI <= 1:
-        #     raise Exception('Nothing to concatenate when there is '
-        # 'only one input series.')
         miflist = []
-        # The following loop first converts NifTis to a .mif file
+        # The following loop converts input file into .mif
         for (idx, i) in enumerate(self.DWIlist):
             if 'nifti' in self.InputType:
                 self.json2fslgrad(i)
@@ -445,7 +446,7 @@ class DWIParser:
             completion = subprocess.run(cmd, shell=True)
             if completion.returncode != 0:
                 raise Exception('Conversion to .mif failed.')
-        # The following command concatenates all DWI(i) in a single
+        # The following command concatenates all DWI(i) into a single
         # .mif file if nDWI > 1
         if self.nDWI > 1:
             cat_arg = ['mrcat -axis 3']

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -10,6 +10,7 @@ import json # decode
 import pprint #pprint
 import numpy as np
 import math
+import warnings
 
 def bvec_is_fullsphere(bvec):
     """Determines if .bvec file is full or half-sphere
@@ -382,14 +383,19 @@ class DWIParser:
     def __init__(self, path):
         UserCpath = path.rsplit(',')
         self.DWIlist = [op.realpath(i) for i in UserCpath]
-        ftype = np.zeros_like(self.DWIlist, dtype=bool)
-        for idx, i in enumerate(self.DWIlist):
-            ftype[idx] = imagetype(i)
+        # This loop determines the types of inputs parsed into the function
+        ftype = []
+        i = 0
+        while i < len(self.DWIlist):
+            ftype.append(imagetype(self.DWIlist[i]))
+            i += 1
         self.InputType = np.unique(ftype)
         if self.InputType.size > 1:
-            raise Exception('DICOM and NifTi inputs cannot be mixed. '
-                            'Please input either input types exclusively.')
-
+            raise IOError('It appears that multiple types of files '
+                            'have been parsed as input. Please input '
+                            'a specific type of input exclusively. '
+                            'Detected inputs were: {}'.format(
+                self.InputType))
         DWIflist = [op.splitext(i) for i in self.DWIlist]
         # Compressed nifti (.nii.gz) have double extensions, and so
         # require double ext-splitting. The following loop takes care of
@@ -399,11 +405,43 @@ class DWIParser:
                 DWIflist[idx] = (op.splitext(i[0])[0], '.nii.gz')
 
         self.DWInlist = [i[0] for i in DWIflist]
-        self.BVALlist = [i + '.bval' for i in self.DWInlist]
-        self.BVEClist = [i + '.bvec' for i in self.DWInlist]
-        self.JSONlist = [i + '.json' for i in self.DWInlist]
+        if 'nifti' in self.InputType:
+            self.BVALlist = [i + '.bval' for i in self.DWInlist]
+            self.BVEClist = [i + '.bvec' for i in self.DWInlist]
+            self.JSONlist = [i + '.json' for i in self.DWInlist]
         self.DWIext = [i[1] for i in DWIflist]
         self.nDWI = len(self.DWIlist)
+
+    # def makeext(self, dwipath):
+    #     """
+    #     Makes FSL grad and JSON extensions for files that don't posses
+    #     header information
+    #
+    #     Parameters
+    #     ----------
+    #     dwipath:    string
+    #                 path to dwi without extension
+    #
+    #     Returns
+    #     -------
+    #     BVALpath:   string
+    #                 path to BVAL
+    #     BVECpath:   string
+    #                 path to BVEC
+    #     JSONpath:   string
+    #                 path to JSON
+    #     """
+    #     # First, check whether an extension to input path exists
+    #     splitpath = op.splitext(dwipath)
+    #     # If an extension does not exist, entered path is valid
+    #     if not splitpath[1]:
+    #         BVALpath = dwipath + '.bval'
+    #         BVECpath = dwipath + '.bvec'
+    #         JSONpath = dwipath + '.json'
+    #     else:
+    #         raise Exception('Ensure that the path to DWI is entered '
+    #                         'without an extension')
+    #     return BVALpath, BVECpath, JSONpath
 
     def cat(self, path, ext='.nii' ,verbose=False, force=False):
         """Concatenates all input series when nDWI > 1 into a 4D NifTi
@@ -426,21 +464,38 @@ class DWIParser:
         miflist = []
         # The following loop converts input file into .mif
         for (idx, i) in enumerate(self.DWIlist):
-            if 'nifti' in self.InputType:
-                self.json2fslgrad(i)
+            if 'nifti' in self.InputType and \
+                    not op.exists(self.JSONlist[idx]):
+                try:
+                    self.json2fslgrad(i)
+                except:
+                    raise IOError('Please supply a valid JSON file '
+                                  'accompanying {}'.format(i))
             convert_args = ['mrconvert -stride 1,2,3,4']
             if verbose is False:
                 convert_args.append('-quiet')
             if force is True:
                 convert_args.append('-force')
-            if op.exists(self.BVEClist[idx]) or \
-                    op.exists(self.BVALlist[idx]):
-                convert_args.append('-fslgrad')
-                convert_args.append(self.BVEClist[idx])
-                convert_args.append(self.BVALlist[idx])
-            if op.exists(self.JSONlist[idx]):
-                convert_args.append('-json_import')
-                convert_args.append(self.JSONlist[idx])
+            if hasattr(self, 'BVEClist') or hasattr(self, 'BVALlist'):
+                if op.exists(self.BVEClist[idx]) or \
+                        op.exists(self.BVALlist[idx]):
+                    convert_args.append('-fslgrad')
+                    convert_args.append(self.BVEClist[idx])
+                    convert_args.append(self.BVALlist[idx])
+                else:
+                    raise FileNotFoundError('BVEC and BVAL pairs for the '
+                                            'input paths do not exist. '
+                                            'Ensure that they exist or '
+                                            'have the same name as DWI.')
+            if hasattr(self, 'JSONlist'):
+                if op.exists(self.JSONlist[idx]):
+                    convert_args.append('-json_import')
+                    convert_args.append(self.JSONlist[idx])
+                else:
+                    warnings.warn('JSON file(s) {} not found. '
+                                  'Attempting to process without. '
+                                  'If processing fails, please use the '
+                                  '"--adv" flag'.format(JSONlist))
             convert_args.append(i)
             convert_args.append(
                 op.join(path, ('dwi' + str(idx) + '.mif')))
@@ -448,7 +503,9 @@ class DWIParser:
             cmd = ' '.join(str(e) for e in convert_args)
             completion = subprocess.run(cmd, shell=True)
             if completion.returncode != 0:
-                raise Exception('Conversion to .mif failed.')
+                raise Exception('Please use the "--force" flag to '
+                                'overwrite existing outputs, or clear '
+                                'the output directory')
         # The following command concatenates all DWI(i) into a single
         # .mif file if nDWI > 1
         if self.nDWI > 1:

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -391,6 +391,9 @@ class DWIParser:
                             'Please input either input types exclusively.')
 
         DWIflist = [op.splitext(i) for i in self.DWIlist]
+        # Compressed nifti (.nii.gz) have double extensions, and so
+        # require double ext-splitting. The following loop takes care of
+        # that.
         if '.gz' in np.unique(np.array(DWIflist)[:,-1])[0]:
             for idx, i in enumerate(DWIflist):
                 DWIflist[idx] = (op.splitext(i[0])[0], '.nii.gz')

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -462,8 +462,6 @@ class DWIParser:
             if completion.returncode != 0:
                 raise Exception('Failed to concatenate multiple '
             'series.')
-            if '.mif' not in ext:
-                miflist.append(op.join(path, 'raw_dwi' + '.mif'))
         else:
             cat_arg = ['mrconvert']
             if verbose is False:
@@ -477,6 +475,8 @@ class DWIParser:
             completion = subprocess.run(cmd, shell=True)
             if completion.returncode != 0:
                 raise Exception('Failed to convert single series')
+        if '.mif' not in ext:
+            miflist.append(op.join(path, 'raw_dwi' + '.mif'))
 
         # Output concatenated .mif into other formats
         if '.mif' not in ext:

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -378,13 +378,6 @@ class DWIParser:
     def __init__(self, path):
         UserCpath = path.rsplit(',')
         self.DWIlist = [op.realpath(i) for i in UserCpath]
-        # acq = np.zeros((len(self.DWIlist)),dtype=bool)
-        # for i,fname in enumerate(self.DWIlist):
-        #     acq[i] = DWIFile(fname).isAcquisition
-        # if not np.any(acq):
-        #     raise Exception('One of the input sequences in not a '
-        #     'valid DWI acquisition. Ensure that the NifTi file is '
-        #     'present with its BVEC/BVAL pair.')
         ftype = np.zeros_like(self.DWIlist, dtype=bool)
         for idx, i in enumerate(self.DWIlist):
             ftype[idx] = imagetype(i)

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -119,6 +119,36 @@ def find_valid_ext(pathname):
     
     return exts
 
+def imagetype(path):
+    """
+    Checks input file type
+
+    Parameters
+    ----------
+    path:   string
+        Directory or file path to inquire
+
+    Returns
+    -------
+    String containing filetype
+    """
+    cmd = ['mrinfo', '-quiet']
+    cmd.append(path)
+    completion = subprocess.run(cmd, stdout=subprocess.PIPE)
+    if completion.returncode != 0:
+        raise IOError('Input {} is not currently supported by '
+                                 'PyDesigner.'.format(path))
+    console = str(completion.stdout).split('\\n')
+    matched_indexes = []
+    i = 0
+    while i < len(console):
+        if 'Format' in console[i]:
+            matched_indexes.append(i)
+        i += 1
+    fstring = console[matched_indexes[0]].split()[1]
+    ftype = ''.join(filter(str.isalpha, fstring)).lower()
+    return ftype
+
 class DWIFile:
     """
     Diffusion data file object, used for handling paths and extensions.

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -223,15 +223,19 @@ args = parser.parse_args()
 # Parse Input Image
 #----------------------------------------------------------------------
 image = DWIParser(args.dwi)
-if image.nDWI > 1:
-    if not args.output:
-        outpath = image.getPath()
-    else:
-        outpath = args.output
-    image.cat(path=outpath,
-              verbose=args.verbose,
-              force=args.force)
-    args.dwi = op.join(outpath, 'raw_dwi.nii')
+# Variable fType indicates the extension to raw_dwi.X, where X take the
+# place of known dMRI file extensions (.mif, .nii, .nii.gz). This allows
+# easy switching based on any scenario for testing.
+fType = '.nii'
+if not args.output:
+    outpath = image.getPath()
+else:
+    outpath = args.output
+image.cat(path=outpath,
+          ext=fType,
+          verbose=args.verbose,
+          force=args.force)
+args.dwi = op.join(outpath, 'raw_dwi' + fType)
 
 #---------------------------------------------------------------------
 # Validate Arguments


### PR DESCRIPTION
This PR closes #33, closes #34, closes #98, closes #118, by adding all MRtrix3-compatible inputs (`dicom`, `.nii`, `.nii.gz`, `.mif`). DWIParser class will now take in a sorted dicom folder and convert it to _.nii_, or as prescribed by `ext` variable in `DWIParser.cat()`. Setting `ext='.mif'` at a later time will allow `.mif` support.