### PR TITLE
Enable MKL flag on AMD systems

### DIFF
--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -15,6 +15,7 @@ import textwrap # dedent
 import numpy as np # array, ndarray
 from preprocessing import util, smoothing, rician, preparation
 from fitting import dwipy as dp
+from system import systemtools as sys
 DWIFile = util.DWIFile
 DWIParser = util.DWIParser
 
@@ -38,7 +39,13 @@ if fsl_location == None:
 # Extract FSL path from fsl_location
 fslpath = op.dirname(fsl_location)
 
-#---------------------------------------------------------------------- 
+# Configure system for Intel MKL
+if sys.isAMD():
+    print('AMD detected')
+    sys.setenv([('MKL_DEBUG_CPU_TYPE','5')])
+    print(os.environ['MKL_DEBUG_CPU_TYPE'])
+
+#----------------------------------------------------------------------
 # Parse Arguments
 #---------------------------------------------------------------------- 
 # Initialize ArgumentParser

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -41,9 +41,7 @@ fslpath = op.dirname(fsl_location)
 
 # Configure system for Intel MKL
 if sys.isAMD():
-    print('AMD detected')
     sys.setenv([('MKL_DEBUG_CPU_TYPE','5')])
-    print(os.environ['MKL_DEBUG_CPU_TYPE'])
 
 #----------------------------------------------------------------------
 # Parse Arguments

--- a/designer/system/__init__.py
+++ b/designer/system/__init__.py
@@ -1,0 +1,1 @@
+from . import systemtools

--- a/designer/system/systemtools.py
+++ b/designer/system/systemtools.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import cpuinfo
+
+def isIntel():
+    """
+    Inquires whether CPU is manufactured by Intel
+
+    Parameters
+    ----------
+    (none)
+
+    Returns
+    -------
+    ans:    bool
+            True if Intel; False otherwise
+    """
+    sysString = cpuinfo.get_cpu_info()['brand']
+    if 'Intel' in sysString:
+        ans = True
+    else:
+        ans = False
+    return ans
+
+def isAMD():
+    """
+    Inquires whether CPU is manufactured by AMD
+
+    Parameters
+    ----------
+    (none)
+
+    Returns
+    -------
+    ans:    bool
+            True if AMD; False otherwise
+    """
+    sysString = cpuinfo.get_cpu_info()['brand']
+    if 'AMD' in sysString:
+        ans = True
+    else:
+        ans = False
+    return ans
+
+def setenv(envlist):
+    """
+    Sets system variables while a Python for the execution of a Python
+    script
+
+    Parameters
+    ----------
+    envlist:    string list
+                List containing environment variables to set. Each entry in
+                the list is a [(ENV_VARIABLE, ENV_VAL)]
+
+    Returns
+    -------
+    (none)      sets system variable
+
+    """
+    environ = dict(os.environ)
+    i = 0
+    while i < len(envlist):
+        os.environ[envlist[i][]0] = envlist[i][1]

--- a/designer/system/systemtools.py
+++ b/designer/system/systemtools.py
@@ -63,4 +63,11 @@ def setenv(envlist):
     environ = dict(os.environ)
     i = 0
     while i < len(envlist):
-        os.environ[envlist[i][]0] = envlist[i][1]
+        # If env variable does not exist
+        if envlist[i][0] not in environ:
+            os.environ[envlist[i][0]] = envlist[i][1]
+        # if env variable exists but has a different value
+        elif (envlist[i][0] in environ) and \
+                (envlist[i][1] not in environ[envlist[i][0]]):
+            os.environ[envlist[i]] = envlist[i][1]
+        i += 1


### PR DESCRIPTION
Adds a CPU check and injects relevant environment variable to enable full instruction support for non-Intel CPUs in MKL numerical library. Tested on real Intel and "faked" AMD system, works as intended. This PR also closes #127.