### PR TITLE
Custom mask path and masking logic improvement

### DIFF
--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -268,8 +268,11 @@ if args.standard:
     # Coerce all of the above to be true
     args.denoise = True
     args.undistort = True
-    args.b1correct = True
     args.smooth = True
+    #--extra options--
+    args.mask = True
+    args.rpe_none = True
+    args.degibbs = True
 
 # Can't do WMTI if no fit
 if args.nofit:

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -638,6 +638,7 @@ if args.mask or args.user_mask:
                         'and saving it in working directory '
                         'as brain_mask.nii. Then use the --resume '
                         'option to continue from here.')
+    print(B0_full + fsl_suffix)
     if op.exists(B0_full + fsl_suffix):
         with gzip.open(B0_full + fsl_suffix, 'r') as f_in, \
                 open(B0_full, 'wb') as f_out:
@@ -665,9 +666,10 @@ if args.mask or args.user_mask:
                             '--resume flag to continue preprocessing from '
                             'here.')
         # Decompress fsl's gunzip format
-        with gzip.open(brainmask_fsl_out, 'r') as f_in, \
-                open(brainmask_out,'wb') as f_out:
-            shutil.copyfileobj(f_in, f_out)
+        if op.exists(brainmask_fsl_out):
+            with gzip.open(brainmask_fsl_out, 'r') as f_in, \
+                    open(brainmask_out,'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
         # Remove .gz file
         if op.exists(brainmask_fsl_out):
             os.remove(brainmask_fsl_out)

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -2,7 +2,7 @@
 Runs the PyDesigner pipeline
 """
 
-#---------------------------------------------------------------------- 
+#----------------------------------------------------------------------
 # Package Management
 #----------------------------------------------------------------------
 import subprocess #subprocess
@@ -45,7 +45,7 @@ if sys.isAMD():
 
 #----------------------------------------------------------------------
 # Parse Arguments
-#---------------------------------------------------------------------- 
+#----------------------------------------------------------------------
 # Initialize ArgumentParser
 parser = argparse.ArgumentParser(
         prog='pydesigner',
@@ -168,10 +168,9 @@ parser.add_argument('--kcumulants', action='store_true', default=False,
                     'rather than K. ')
 parser.add_argument('--mask', action='store_true', default=False,
                     help='Compute a brain mask prior to tensor fitting '
-                    'to strip skull and improve efficiency. Use '
-                     '--maskthr to specify a threshold manually.')
-parser.add_argument('--maskthr', metavar='<fractional intensity '
-                                             ' threshold>',
+                    'to strip skull and improve efficiency. Optionally, '
+                    'use --maskthr to specify a threshold manually.')
+parser.add_argument('--maskthr', metavar='FA Threshold',
                     help='FSL bet threshold used for brain masking. '
                     'Default: 0.25')
 parser.add_argument('--user_mask',
@@ -325,7 +324,7 @@ if args.user_mask:
         errmsg+='--user_mask file '+args.user_mask+' not found\n'
     # Then check if it's a nifti file
     if not '.nii' in op.splitext(args.user_mask)[-1]:
-        errmsg+='User supplied mask if not in NifTi(.nii) format.'
+        errmsg+='User supplied mask if not in NifTi (.nii) format.'
 
 # Check output directory exists if given
 if args.output:
@@ -591,7 +590,7 @@ if args.undistort:
         filetable['undistorted'] = DWIFile(undistorted_full)
         filetable['HEAD'] = filetable['undistorted']
 
-#---------------------------------------------------------------------- 
+#----------------------------------------------------------------------
 # Create Brain Mask
 #----------------------------------------------------------------------
 if args.mask:
@@ -732,7 +731,7 @@ if args.rician:
     filetable['rician_corrected'] = DWIFile(rician_full)
     filetable['HEAD'] = filetable['rician_corrected']
 
-#---------------------------------------------------------------------- 
+#----------------------------------------------------------------------
 # Make preprocessed file
 #----------------------------------------------------------------------
 preprocessed = op.join(outpath, 'preprocessed_dwi')

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -638,9 +638,10 @@ if args.mask or args.user_mask:
                         'and saving it in working directory '
                         'as brain_mask.nii. Then use the --resume '
                         'option to continue from here.')
-    with gzip.open(B0_full + fsl_suffix, 'r') as f_in, \
-            open(B0_full, 'wb') as f_out:
-        shutil.copyfileobj(f_in, f_out)
+    if op.exists(B0_full + fsl_suffix):
+        with gzip.open(B0_full + fsl_suffix, 'r') as f_in, \
+                open(B0_full, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
     # Remove all other files
     if op.exists(B0_mean_full):
         os.remove(B0_mean_full)

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -680,7 +680,14 @@ if args.mask or args.user_mask:
         filetable['mask'] = DWIFile(brainmask_out)
     elif args.user_mask:
         brainmask_out = op.join(outpath, 'brain_mask.nii')
-        shutil.copyfile(args.user_mask, brainmask_out)
+        if outpath is args.dwi:
+            shutil.copy(args.user_mask, brainmask_out)
+        else:
+            print('WARNING: Brain mask {} already exists in your output '
+                  'directory. Your output directory is the same as input '
+                  'if you ran without the "-o" flag. Proceeding without '
+                  'overwriting the already existent file.'.format(
+                brainmask_out))
         filetable['mask'] = DWIFile(brainmask_out)
     else:
         filetable['mask'] = None

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -678,6 +678,8 @@ if args.mask or args.user_mask:
         filetable['mask'] = DWIFile(brainmask_out)
     else:
         filetable['mask'] = None
+else:
+    filetable['mask'] = None
 
 #----------------------------------------------------------------------
 # Smooth

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -170,10 +170,10 @@ parser.add_argument('--mask', action='store_true', default=False,
                     help='Compute a brain mask prior to tensor fitting '
                     'to strip skull and improve efficiency. Optionally, '
                     'use --maskthr to specify a threshold manually.')
-parser.add_argument('--maskthr', metavar='FA Threshold',
+parser.add_argument('--maskthr', metavar='<FA threshold>',
                     help='FSL bet threshold used for brain masking. '
                     'Default: 0.25')
-parser.add_argument('--user_mask',
+parser.add_argument('--user_mask', metavar='<brain mask path>',
                     help='Path to user-supplied brain mask.',
                     type=str)
 parser.add_argument('--fit_constraints', default='0,1,0',


### PR DESCRIPTION
Users can now supply their own brain masks using one of two ways:
1. Place a file called _brain_mask.nii_ in output folder
2. Parse the `--user_mask [PATH]` flag to point to absolute path of mask file

The logic has also been redefined such that B0 is extracted nevertheless to close #140, and to generate a B0 each time either masking parameters are used.