### PR TITLE
Change `dwipreproc` CWD

### DIFF
--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -586,7 +586,7 @@ if args.undistort:
         dwipreproc_args.append(undistorted_full)
         if args.verbose:
             print(*dwipreproc_args)
-        completion = subprocess.run(dwipreproc_args)
+        completion = subprocess.run(dwipreproc_args, cwd=outpath)
         if completion.returncode != 0:
             raise Exception('dwipreproc failed, please look above for '
                             'error sources.')

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -375,8 +375,10 @@ if args.degibbs and args.adv:
     args.degibbs = True
 else:
     if args.degibbs and filetable['dwi'].isPartialFourier():
-        print('Given DWI is partial fourier, overriding --degibbs; '
-              'no unringing correction will be done to avoid artifacts.')
+        print('[WARNING] Given DWI is partial fourier, overriding '
+              '--degibbs; no unringing correction will be done to '
+              'avoid artifacts.Use the "--adv" flag to run forced '
+              'corrections.')
         args.degibbs = False
 
 if args.rpe_pair:
@@ -683,11 +685,11 @@ if args.mask or args.user_mask:
         if outpath is args.dwi:
             shutil.copy(args.user_mask, brainmask_out)
         else:
-            print('WARNING: Brain mask {} already exists in your output '
-                  'directory. Your output directory is the same as input '
-                  'if you ran without the "-o" flag. Proceeding without '
-                  'overwriting the already existent file.'.format(
-                brainmask_out))
+            print('[WARNING] Brain mask {} already exists in your '
+                  'output directory. Your output directory is the '
+                  'same as input if you ran without the "-o" flag. '
+                  'Proceeding without overwriting the existing '
+                  'file.'.format(brainmask_out))
         filetable['mask'] = DWIFile(brainmask_out)
     else:
         filetable['mask'] = None


### PR DESCRIPTION
This PR runs `dwipreproc` into the output directory instead of current working directory. Doing so containerizes all file I/O within the output directory whilst leaving the PyDesigner directory clean. This also closes #139 since file I/O is no longer cross-device between host and emulated container.