### PR TITLE
Intel MKL Bugfix Patch [1/2]

### DIFF
--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -1380,7 +1380,7 @@ class DWI(object):
                     #     bmat.T, np.log(dwi)))
                 except:
                     dt_ = np.full((bmat.shape[1], 1), minZero)
-                w = np.exp(np.matmul(bmat, dt_)).reshape((ndwi, 1))
+                w = sigmoid(np.matmul(bmat, dt_)).reshape((ndwi, 1))
                 try:
                     dt_ = np.linalg.lstsq((bmat * np.tile(w, (1, nparam))),
                                           (np.log(dwi) * w), rcond=None)[0]
@@ -1423,14 +1423,16 @@ class DWI(object):
             n_i = dwi_i.size
             ndof_i = n_i - bmat_i.shape[1]
             # WLLS estimation
-
             try:
                 dt_i = np.linalg.lstsq(bmat_i, np.log(dwi_i), rcond=None)[0]
                 # dt_i = np.linalg.solve(np.dot(bmat_i.T, bmat_i),
                 #                        np.dot(bmat_i.T, np.log(dwi_i)))
             except:
                 dt_i = np.full((bmat_i.shape[1], 1), minZero)
-            w = np.exp(np.matmul(bmat_i, dt_i))
+            try:
+                w = sigmoid(np.matmul(bmat_i, dt_i))
+            except:
+                w = np.full((bmat_i.shape[1], 1), minZero)
             try:
                 dt_i = np.linalg.lstsq((bmat_i * np.tile(w, (1, nparam))),
                                        (np.log(dwi_i).reshape(
@@ -1444,12 +1446,13 @@ class DWI(object):
                 #                (dwi_i.shape[0], 1)) * w)))
             except:
                 dt_i = np.full((bmat_i.shape[1], 1), minZero)
-            dwi_hat = np.exp(np.matmul(bmat_i, dt_i))
+            dwi_hat = sigmoid(np.matmul(bmat_i, dt_i))
 
             # Goodness-of-fit
             residu = np.log(dwi_i.reshape((dwi_i.shape[0],1))) - \
                      np.log(dwi_hat)
             residu_ = dwi_i.reshape((dwi_i.shape[0],1)) - dwi_hat
+            
             try:
                 chi2 = np.sum((residu_ * residu_) /\
                               np.square(sigma)) / (ndof_i) -1
@@ -1494,7 +1497,7 @@ class DWI(object):
                     #                (dwi_i.shape[0], 1)) * w)))
                 except:
                     dt_i = np.full((bmat_i.shape[1], 1), minZero)
-                dwi_hat = np.exp(np.matmul(bmat_i, dt_i))
+                dwi_hat = sigmoid(np.matmul(bmat_i, dt_i))
                 dwi_hat[dwi_hat < 1] = 1
                 residu = np.log(
                     dwi_i.reshape((dwi_i.shape[0],1))) - np.log(dwi_hat)
@@ -1552,7 +1555,7 @@ class DWI(object):
                 #                     np.dot(bmat_i.T, np.log(dwi_i)))
             except:
                 dt_ = np.full((bmat_i.shape[1], 1), minZero)
-            w = np.exp(np.matmul(bmat_i, dt_))
+            w = sigmoid(np.matmul(bmat_i, dt_))
             try:
                 dt = np.linalg.lstsq((bmat_i * np.tile(w.reshape((len(w),1)), (1, nparam))), (np.log(dwi_i).reshape((dwi_i.shape[0], 1)) * w.reshape((len(w),1))),
                                            rcond=None)[0]

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -1466,6 +1466,7 @@ class DWI(object):
             gof2 = gof
             # Iterative reweighning procedure
             iter = 0
+            
             while (not gof) and (iter < maxiter):
                 try:
                     C = np.sqrt(n_i/(n_i-nparam)) * \
@@ -1575,7 +1576,6 @@ class DWI(object):
             #      np.sqrt(np.square(eigv[0]) + np.square(eigv[1]) + np.square(eigv[2])))
             # md = np.sum(eigv)/3
             return reject.reshape(-1), dt.reshape(-1)#, fa, md
-        np.seterr(invalid='raise', divide='raise')
         inputs = tqdm(range(nvox),
                           desc='IRLLS: Outlier Detection',
                           unit='vox',
@@ -1584,7 +1584,6 @@ class DWI(object):
             (delayed(outlierHelper)(dwi[:, i], bmat, sigma[i,0], b, b0_pos) for i in inputs))
         # for i in inputs:
         #     reject[:,i], dt[:,i] = outlierHelper(dwi[:, i], bmat, sigma[i,0], b, b0_pos)
-        np.seterr(**defaultErrorState)
         dt = np.array(dt)
         # self.dt = dt
         #Unscaling

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -8,7 +8,6 @@ import cvxpy as cvx
 import nibabel as nib
 import numpy as np
 from joblib import Parallel, delayed
-from scipy.special import expit as sigmoid
 import scipy.linalg as sla
 from tqdm import tqdm
 from . import dwidirs
@@ -580,7 +579,7 @@ class DWI(object):
         dwi_ = vectorize(self.img, self.mask)
         reject_ = vectorize(reject, self.mask).astype(bool)
         init = np.matmul(np.linalg.pinv(self.b), np.log(dwi_))
-        shat = np.exp(np.matmul(self.b, init))
+        shat = highprecisionexp(np.matmul(self.b, init))
         if constraints is None or (constraints[0] == 0 and
                                    constraints[1] == 0 and
                                    constraints[2] == 0):
@@ -607,7 +606,7 @@ class DWI(object):
                                          self.b[~reject_[:, i]],
                                          cons=C) for i in inputs)
         self.dt = np.reshape(self.dt, (dwi_.shape[1], self.b.shape[1])).T
-        self.s0 = np.exp(self.dt[0,:])
+        self.s0 = highprecisionexp(self.dt[0,:])
         self.dt = self.dt[1:,:]
         D_apprSq = 1/(np.sum(self.dt[(0,3,5),:], axis=0)/3)**2
         self.dt[6:,:] = self.dt[6:,:]*np.tile(D_apprSq, (15,1))
@@ -693,7 +692,7 @@ class DWI(object):
                             self.dt[2, :], self.dt[4, :], self.dt[5, :])),
             (3, 3, self.dt.shape[1]))
         # get the trace
-        rdwi = sigmoid(np.matmul(self.b[:, 1:], self.dt))
+        rdwi = highprecisionexp(np.matmul(self.b[:, 1:], self.dt))
         B = np.round(-(self.b[:, 0] + self.b[:, 3] + self.b[:, 5]) * 1000)
         uB = np.unique(B)
         trace = np.zeros((self.dt.shape[1], uB.shape[0]))
@@ -752,7 +751,7 @@ class DWI(object):
         trace:  sum of first eigenvalues
         """
         # get the trace
-        rdwi = sigmoid(np.matmul(self.b[:, 1:], self.dt))
+        rdwi = highprecisionexp(np.matmul(self.b[:, 1:], self.dt))
         B = np.round(-(self.b[:, 0] + self.b[:, 3] + self.b[:, 5]) * 1000)
         uB = np.unique(B)
         trace = np.zeros((self.dt.shape[1], uB.shape[0]))
@@ -848,7 +847,6 @@ class DWI(object):
                 ias_rd = minZero
                 ias_tort = minZero
             return eas_ad, eas_rd, eas_tort, ias_ad, ias_rd, ias_tort
-        np.seterr(invalid='raise', divide='raise')
         dir = dwidirs.dirs10000
         nvox = self.dt.shape[1]
         N = dir.shape[0]
@@ -900,7 +898,6 @@ class DWI(object):
         ias_ad = vectorize(np.array(ias_ad), self.mask)
         ias_rd = vectorize(np.array(ias_rd), self.mask)
         ias_tort = vectorize(np.array(ias_tort), self.mask)
-        np.seterr(**defaultErrorState)
         return awf, eas_ad, eas_rd, eas_tort, ias_ad, ias_rd, ias_tort
 
     def findViols(self, c=[0, 1, 0]):
@@ -1380,7 +1377,7 @@ class DWI(object):
                     #     bmat.T, np.log(dwi)))
                 except:
                     dt_ = np.full((bmat.shape[1], 1), minZero)
-                w = sigmoid(np.matmul(bmat, dt_)).reshape((ndwi, 1))
+                w = highprecisionexp(np.matmul(bmat, dt_)).reshape((ndwi, 1))
                 try:
                     dt_ = np.linalg.lstsq((bmat * np.tile(w, (1, nparam))),
                                           (np.log(dwi) * w), rcond=None)[0]
@@ -1429,10 +1426,7 @@ class DWI(object):
                 #                        np.dot(bmat_i.T, np.log(dwi_i)))
             except:
                 dt_i = np.full((bmat_i.shape[1], 1), minZero)
-            try:
-                w = sigmoid(np.matmul(bmat_i, dt_i))
-            except:
-                w = np.full((bmat_i.shape[1], 1), minZero)
+            w = highprecisionexp(np.matmul(bmat_i, dt_i))
             try:
                 dt_i = np.linalg.lstsq((bmat_i * np.tile(w, (1, nparam))),
                                        (np.log(dwi_i).reshape(
@@ -1446,8 +1440,7 @@ class DWI(object):
                 #                (dwi_i.shape[0], 1)) * w)))
             except:
                 dt_i = np.full((bmat_i.shape[1], 1), minZero)
-            dwi_hat = sigmoid(np.matmul(bmat_i, dt_i))
-
+            dwi_hat = highprecisionexp(np.matmul(bmat_i, dt_i))
             # Goodness-of-fit
             residu = np.log(dwi_i.reshape((dwi_i.shape[0],1))) - \
                      np.log(dwi_hat)
@@ -1498,7 +1491,7 @@ class DWI(object):
                     #                (dwi_i.shape[0], 1)) * w)))
                 except:
                     dt_i = np.full((bmat_i.shape[1], 1), minZero)
-                dwi_hat = sigmoid(np.matmul(bmat_i, dt_i))
+                dwi_hat = highprecisionexp(np.matmul(bmat_i, dt_i))
                 dwi_hat[dwi_hat < 1] = 1
                 residu = np.log(
                     dwi_i.reshape((dwi_i.shape[0],1))) - np.log(dwi_hat)
@@ -1556,7 +1549,7 @@ class DWI(object):
                 #                     np.dot(bmat_i.T, np.log(dwi_i)))
             except:
                 dt_ = np.full((bmat_i.shape[1], 1), minZero)
-            w = sigmoid(np.matmul(bmat_i, dt_))
+            w = highprecisionexp(np.matmul(bmat_i, dt_))
             try:
                 dt = np.linalg.lstsq((bmat_i * np.tile(w.reshape((len(w),1)), (1, nparam))), (np.log(dwi_i).reshape((dwi_i.shape[0], 1)) * w.reshape((len(w),1))),
                                            rcond=None)[0]
@@ -1831,3 +1824,32 @@ def clipImage(img, range):
     img[img > range[1]] = range[1]
     img[img < range[0]] = range[0]
     return img
+
+def highprecisionexp(array, maxp=1e32):
+    """Prevents overflow warning with numpy.exp by assigning overflows
+    to a maxumum precision value
+    Classification: Function
+
+    Usage
+    -----
+    a = highprecisionexp(array)
+
+    Parameters
+    ----------
+    array:  array or scalar of number to run np.exp on
+    maxp: maximum preicison to assign if overflow
+        default: 1E32
+
+    Returns
+    -------
+    exponent or max-precision
+    """
+    np.seterr(all='ignore')
+    defaultErrorState = np.geterr()
+    np.seterr(over='raise', invalid='raise')
+    try:
+        ans = np.exp(array)
+    except:
+        ans = np.full(array.shape, maxp)
+    np.seterr(**defaultErrorState)
+    return ans


### PR DESCRIPTION
This PR resolves a lot of MKL errors by assigning a max high precision of 1E32 in overflowing exponentials. There are still some stray MKL errors, but this should fix ~99% percent of them.

The other 1% will be attended to when I return from vacation.