### PR TITLE
Postprocessing median filter

### DIFF
--- a/designer/postprocessing/filters.py
+++ b/designer/postprocessing/filters.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding : utf-8 -*-
+
+"""
+This module contains filter(s) for postprocessing DTI/DKI maps
+"""
+#---------------------------------------------------------------------
+# Package Management
+#---------------------------------------------------------------------
+import os.path as op
+import numpy as np
+from scipy.ndimage import median_filter, generate_binary_structure
+import nibabel as nib
+
+#---------------------------------------------------------------------
+# Functions
+#---------------------------------------------------------------------
+def readnii(input):
+    """
+    Reads nifti files and returns header and numpy data array
+
+    Parameters
+    ----------
+    input: path to nifti fule
+
+    Returns
+    -------
+    img:    numpy array
+    hdr:    image header
+    """
+    hdr = nib.load(input)
+    img = np.array(hdr.dataobj)
+    return hdr, img
+
+def writenii(hdr, img, output):
+    """
+    Write nupy array to nifti file
+
+    Parameters
+    ----------
+    hdr:    image header
+    img:    numpy array
+    output: path to save file as
+    """
+    struct = nib.Nifti1Image(img, hdr.affine, hdr.header)
+    nib.save(struct, output)
+
+def median(input, output, mask=None):
+    """
+    Applies median filtering to input nifti file
+
+    Parameters
+    ----------
+    input:  path to input nifti file
+    output: path to output nifti file
+    mask:   path to brainmask nifti file
+            default: None
+
+    Returns
+    -------
+    written to drive
+    """
+    if not op.exists(input):
+        raise IOError('Input file {} does not exist.'.format(input))
+    hdr, img = readnii(input)
+    if mask is not None:
+        if not op.exists(mask):
+            raise IOError('Input mask {} does not '
+                          'exist.'.format(input))
+        maskhdr, mask = readnii(mask)
+    else:
+        mask = np.ones((img.shape[0], img.shape[1], img.shape[2]),
+                        order='F')
+    mask.astype(bool)
+    conn = generate_binary_structure(rank=3, connectivity=1)
+    if np.ndim(img) == 4:
+        for i in range(img.shape[-1]):
+            img[:, :, :, i] = median_filter(img[:, :, :, i],
+                                                footprint=conn,
+                                                mode='constant',
+                                                cval=float('nan')) \
+                                                    * mask
+    elif np.ndim(img) == 3:
+        img = median_filter(img, 
+                            footprint=conn,
+                            mode='constant', cval=float('nan')) \
+                                * mask
+    else:
+        raise Exception('Input nifti image needs to be either 3D or '
+                        '4D. Please check the file provided.')
+    writenii(hdr, img, output)

--- a/designer/postprocessing/medianfilter.py
+++ b/designer/postprocessing/medianfilter.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# -*- coding : utf-8 -*-
+
+"""
+Median filter module written specifically for PyDesigner. This method
+uses nothing other than NumPy to keep dependencies low.
+"""

--- a/designer/postprocessing/medianfilter.py
+++ b/designer/postprocessing/medianfilter.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-# -*- coding : utf-8 -*-
-
-"""
-Median filter module written specifically for PyDesigner. This method
-uses nothing other than NumPy to keep dependencies low.
-"""

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -854,6 +854,7 @@ def main():
         else:
             mk, rk, ak, kfa, mkt, trace = img.extractDKI()
         if args.median:
+            conn = generate_binary_structure(rank=3, connectivity=1)
             mk = median_filter(mk,
                                 footprint=conn,
                                 mode='constant', cval=float('nan')) \


### PR DESCRIPTION
This PR adds a postprocessing median filter flag for poor acquisitions demonstrating a large number of dropouts. It works by simply applying a 3-by-3 median box filter with 6-connectivity given by:

```
[[[False False False]
  [False  True False]
  [False False False]]

 [[False  True False]
  [ True  True  True]
  [False  True False]]

 [[False False False]
  [False  True False]
  [False False False]]]
```

A demonstration of the effect of this filter on kurtosis fractional anisotropy (KFA) map is shown below:

Original KFA:
<img width="572" alt="Screen Shot 2020-01-27 at 5 55 20 PM" src="https://user-images.githubusercontent.com/13654344/73221389-b6d5fe00-412e-11ea-9991-99b131a77f00.png">

KFA with median filter applied:
<img width="571" alt="Screen Shot 2020-01-27 at 5 59 01 PM" src="https://user-images.githubusercontent.com/13654344/73221414-c5241a00-412e-11ea-94a0-07b4f3bd30fd.png">


This filter is off by default and is only recommended for low quality datasets. When applied, the filter alters the values of most voxels, so it should be used with caution and avoided when data quality is otherwise adequate. While maps appear visually soother with this flag on, they may nonetheless be less accurate.