### PR TITLE
Add RTD config to install

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,3 +21,4 @@ python:
   version: 3.6
   install:
     - requirements: docs/requirements.txt
+    - setup_py_install: true

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,6 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['build/']
 
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
Fixes issue of `designer` module not being found when building docs remotely.