### PR TITLE
RTD bugfix for `module not found`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,5 +22,5 @@ python:
   install:
      - requirements: docs/requirements.txt
      - method: pip
-       path: designer/setup.py
+       path: .
   system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,5 +22,5 @@ python:
   install:
      - requirements: docs/requirements.txt
      - method: pip
-       path: ../designer
+       path: designer
   system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,5 +22,5 @@ python:
   install:
      - requirements: docs/requirements.txt
      - method: pip
-       path: designer
+       path: designer/setup.py
   system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,5 +20,7 @@ formats: all
 python:
   version: 3.6
   install:
-    - requirements: docs/requirements.txt
-    - setup_py_install: true
+     - requirements: docs/requirements.txt
+     - method: pip
+       path: ../designer
+  system_packages: true

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from designer.info import (
     CLASSIFIERS
 )
 
-with open("README.md", "r") as fh:
+with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
Allows RTD to install pydesigner for autodoc building.