### PR TITLE
Add flag for version

### DIFF
--- a/designer/info.py
+++ b/designer/info.py
@@ -10,7 +10,7 @@ __execdir__ = os.path.basename(
     )
 )
 __packagename__ = 'PyDesigner'
-__version__='0.2'
+__version__='v0.3'
 __author__ = 'PyDesigner developers'
 __copyright__ = 'Copyright 2020, PyDesigner developers, MUSC Advanced Image Analysis (MAMA)'
 __credits__ = [

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -15,6 +15,7 @@ import argparse # ArgumentParser, add_argument
 import textwrap # dedent
 import json
 import numpy as np # array, ndarray
+from designer.info import __version__
 from designer.preprocessing import util, preparation, mrinfoutil, mrpreproc
 from designer.plotting import snrplot, outlierplot, motionplot
 from designer.fitting import dwipy as dp
@@ -214,6 +215,8 @@ def main():
                         'UNDERSTAND THE MRI SYSTEM AND ITS OUTPUTS. '
                         'RUNNING WITH THIS FLAG COULD POTENTIALLY '
                         'RESULT IN IMPRECISE AND INACCURATE RESULTS.')
+    parser.add_argument('-v', '--version', action='version',
+                        version=__version__)
 
     # Use argument specification to actually get args
     args = parser.parse_args()


### PR DESCRIPTION
Users may now parse the flag `-v` or `--version` to view their PyDesigner version.