### PR TITLE
Create symbolic link from bash to sh

### DIFF
--- a/docker/Dockerfile_develop
+++ b/docker/Dockerfile_develop
@@ -57,7 +57,7 @@ RUN apt-get install -y --no-install-recommends \
       libtiff5-dev \
       libomp-dev
 
-ARG DEBIAN_FRONTEND=noninteractive
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 # Clone PyDesigner
 RUN mkdir -p /tmp/PyDesigner


### PR DESCRIPTION
This fixes bash errors in Docker build of `develop` branch