### PR TITLE
Enhanced reslicing

### DIFF
--- a/designer/preprocessing/mrinfoutil.py
+++ b/designer/preprocessing/mrinfoutil.py
@@ -26,7 +26,7 @@ def getconsole(path, flag):
     Returns
     -------
     str
-        MRtrix3's mrinfo conmsol output
+        MRtrix3's mrinfo console output
     """
     if not op.exists(path):
         raise OSError('Input path does not exist. Please ensure that the '

--- a/designer/preprocessing/mrpreproc.py
+++ b/designer/preprocessing/mrpreproc.py
@@ -933,10 +933,10 @@ def reslice(input, output, size, interp='linear',
     if not isinstance(verbose, bool):
         raise Exception('Please specify whether verbose is True or False.')
     if dim_str == '-voxel':
-        current_size = [float(x) for x in (mrinfoutil.spacing(input))][0:3]
+        current_size = [round(float(x), 2) for x in (mrinfoutil.spacing(input))][0:3]
     elif dim_str == '-size':
-        current_size =[float(x) for x in mrinfoutil.size(input)][0:3]
-    specified_size = [float(x) for x in size.split(',')]
+        current_size =[round(float(x), 2) for x in mrinfoutil.size(input)][0:3]
+    specified_size = [round(float(x), 2) for x in size.split(',')]
     if specified_size == current_size:
         print('[WARNING] target reslicing dimensions {} are the same '
             'as input image dimensions {}, writing file without '

--- a/designer/preprocessing/mrpreproc.py
+++ b/designer/preprocessing/mrpreproc.py
@@ -391,6 +391,10 @@ def undistort(input, output, rpe='rpe_header', epib0=1,
         except:
             print('[WARNING] Unable to apply EPI boost because DWI '
             'consists of single PE direction.')
+            try:
+                os.remove(op.join(outdir, 'B0_ALL.mif'))
+            except OSError:
+                pass
     arg.extend(['-eddy_options', repol_string])
     arg.append(rpe)
     if not qc is None:

--- a/designer/preprocessing/mrpreproc.py
+++ b/designer/preprocessing/mrpreproc.py
@@ -389,8 +389,10 @@ def undistort(input, output, rpe='rpe_header', epib0=1,
                     verbose=verbose)
             arg.extend(['-se_epi', epi_path])
         except:
-            print('[WARNING] Unable to apply EPI boost because DWI '
+            print('[WARNING] Unable to apply TOPUPBOOST because DWI '
             'consists of single PE direction.')
+            # Remove the B0_ALL.mif file that is created when epiboost
+            # function fails
             try:
                 os.remove(op.join(outdir, 'B0_ALL.mif'))
             except OSError:

--- a/designer/preprocessing/mrpreproc.py
+++ b/designer/preprocessing/mrpreproc.py
@@ -389,8 +389,13 @@ def undistort(input, output, rpe='rpe_header', epib0=1,
                     verbose=verbose)
             arg.extend(['-se_epi', epi_path])
         except:
-            print('[WARNING] Unable to apply TOPUPBOOST because DWI '
+            print('[WARNING] Unable to apply EPI boost because DWI '
             'consists of single PE direction.')
+            try:
+                os.remove(op.join(outdir, 'B0_ALL.mif'))
+            except OSError:
+                pass
+    arg.extend(['-eddy_options', repol_string])
     arg.append(rpe)
     if not qc is None:
         arg.extend(['-eddyqc_all', qc])
@@ -773,7 +778,7 @@ def epiboost(input, output, num=1, nthreads=None, force=False,
     -------
     None; writes out file
     """
-    print('TOPUPBOOST: Splitting {} user-specified RPE pairs'.format(num))
+    print('Applying EPIBOOST')
     if not op.exists(input):
         raise OSError('Input path does not exist. Please ensure that '
                       'the folder or file specified exists.')
@@ -800,68 +805,63 @@ def epiboost(input, output, num=1, nthreads=None, force=False,
         raise Exception('Please specify whether verbose is True or False.')
     outdir = op.dirname(output)
     fname_bzero = op.join(outdir, 'B0_ALL.mif')
-    try:
-        # Extract all B0s
-        extractbzero(input, fname_bzero, nthreads=nthreads, force=force,
-                verbose=verbose)
-        # Start by figuring out whether DWI is composed of multiple PE dirs
-        # or single PE dirs. If all PE dirs are the same, the dataset likely
-        # comes with matching phase encoding and slice timing train,
-        # indicating that it has a single PE direction.
-        dw_scheme = np.array(mrinfoutil.dwscheme(fname_bzero), dtype=int)[:, -1]
-        pe_scheme = np.array(mrinfoutil.pescheme(fname_bzero))
-        if len(pe_scheme) != len(dw_scheme):
-            raise Exception('It appears that the input volume possesses a '
-                            'dw_scheme of length {}, and pe_scheme of length '
-                            '{}. These number need to match. Please check '
-                            'your dataset or contact us on GitHub'.format(
-                len(dw_scheme), len(pe_scheme)))
-        uPE, indPE, iPE = np.unique(pe_scheme, axis=0, return_index=True,
-                                    return_inverse=True)
-        nPE = len(uPE)
-        if nPE < 2:
-            raise Exception('DWI consists of just one PE direction. '
-                            'Unable to extract B0s.')
-        # Index unique PE directions
-        bval = []
-        bind = []
-        iteridx = np.unique(iPE)
-        for i, val in enumerate(iteridx):
-            bind.append(np.where(iPE == val)[0].tolist())
-            bval.append(dw_scheme[np.where(iPE == val)].tolist())
-        # Check whether number of B0s to extract exceed those in DWI
-        if num > min([len(x) for x in bval]):
-            raise Exception('Specified number of B0s pairs to extract '
-                            '({}) exceed those physically present in DWI '
-                            '({}), please ensure that variable `num` '
-                            'suitably represents the number of B0s in DWI.'
-                            .format(num, min([len(x) for x in bval])))
-        # Extract the first `num` pairs from each PE direction
-        num = np.arange(0, num, dtype=int).tolist()
-        idx_extract = []
-        for idx, val in enumerate(bind):
-            idx_extract.extend([val[i] for i in num])
-        # Extract EPI volume
-        str_extract = [str(x) for x in idx_extract]
-        arg_epi = ['mrconvert']
-        if force:
-            arg_epi.append('-force')
-        if not verbose:
-            arg_epi.append('-quiet')
-        if not (nthreads is None):
-            arg_epi.extend(['-nthreads', nthreads])
-        arg_epi.extend(['-coord', '3', ','.join(str_extract)])
-        arg_epi.extend([fname_bzero, output])
-        completion = subprocess.run(arg_epi)
-        if completion.returncode != 0:
-            raise Exception('TOPUPBOOST: failed to extract specified '
-                            'TOPUP B0 indices. See above for errors.')
-    except:
-        # Remove temp files
-        os.remove(fname_bzero)
-        raise Exception('TOPUPBOOST: failed to extract specified '
+    # Extract all B0s
+    extractbzero(input, fname_bzero, nthreads=nthreads, force=force,
+              verbose=verbose)
+    # Start by figuring out whether DWI is composed of multiple PE dirs
+    # or single PE dirs. If all PE dirs are the same, the dataset likely
+    # comes with matching phase encoding and slice timing train,
+    # indicating that it has a single PE direction.
+    dw_scheme = np.array(mrinfoutil.dwscheme(fname_bzero), dtype=int)[:, -1]
+    pe_scheme = np.array(mrinfoutil.pescheme(fname_bzero))
+    if len(pe_scheme) != len(dw_scheme):
+        raise Exception('It appears that the input volume possesses a '
+                        'dw_scheme of length {}, and pe_scheme of length '
+                         '{}. These number need to match. Please check '
+                        'your dataset or contact us on GitHub'.format(
+            len(dw_scheme), len(pe_scheme)))
+    uPE, indPE, iPE = np.unique(pe_scheme, axis=0, return_index=True,
+                                return_inverse=True)
+    nPE = len(uPE)
+    if nPE < 2:
+        raise Exception('DWI consists of just one PE direction. '
+                        'Unable to extract B0s.')
+    # Index unique PE directions
+    bval = []
+    bind = []
+    iteridx = np.unique(iPE)
+    for i, val in enumerate(iteridx):
+        bind.append(np.where(iPE == val)[0].tolist())
+        bval.append(dw_scheme[np.where(iPE == val)].tolist())
+    # Check whether number of B0s to extract exceed those in DWI
+    if num > min([len(x) for x in bval]):
+        raise Exception('Specified number of B0s pairs to extract '
+                        '({}) exceed those physically present in DWI '
+                        '({}), please ensure that variable `num` '
+                        'suitably represents the number of B0s in DWI.'
+                        .format(num, min([len(x) for x in bval])))
+    # Extract the first `num` pairs from each PE direction
+    num = np.arange(0, num, dtype=int).tolist()
+    idx_extract = []
+    for idx, val in enumerate(bind):
+        idx_extract.extend([val[i] for i in num])
+    # Extract EPI volume
+    str_extract = [str(x) for x in idx_extract]
+    arg_epi = ['mrconvert']
+    if force:
+        arg_epi.append('-force')
+    if not verbose:
+        arg_epi.append('-quiet')
+    if not (nthreads is None):
+        arg_epi.extend(['-nthreads', nthreads])
+    arg_epi.extend(['-coord', '3', ','.join(str_extract)])
+    arg_epi.extend([fname_bzero, output])
+    completion = subprocess.run(arg_epi)
+    if completion.returncode != 0:
+        raise Exception('EPIBOOST: failed to extract specified '
                         'TOPUP B0 indices. See above for errors.')
-    
+    # Remove temp files
+    os.remove(fname_bzero)
 
 def reslice(input, output, size, interp='linear',
             nthreads=None, force=False, verbose=False):

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -149,7 +149,7 @@ def main():
     parser.add_argument('--undistort', action='store_true', default=False,
                         help='Run FSL eddy to perform image undistortion. '
                         'NOTE: needs a --topup to run.')
-    parser.add_argument('--epi', default=0, type=int,
+    parser.add_argument('--rpe_pairs', default=0, type=int,
                         metavar='n',
                         help='Number of reverse phase encoded B0 '
                         'pairs to use in TOPUP. Using less pairs '
@@ -596,7 +596,7 @@ def main():
                                 output=mif_undistorted,
                                 rpe='rpe_header',
                                 qc=eddyqcpath,
-                                epib0=args.epi,
+                                epib0=args.rpe_pairs,
                                 nthreads=args.nthreads,
                                 force=args.force,
                                 verbose=args.verbose)

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -94,12 +94,10 @@ def main():
         1. dwidenoise (thermal denoising)
         2. mrdegibbs (gibbs unringing)
         3. topup + eddy (undistortion)
-        4. b1 bias correction
-        4. CSF-excluded smoothing
-        5. rician bias correction
-        6. normalization to white matter in first b0 image
-        7. IRWLLS, CWLLS DKI fit
-        8. Outlier detection and removal
+        4. rician bias correction
+        5. normalization to white matter in first b0 image
+        6. IRWLLS, CWLLS DKI fit
+        7. Outlier detection and removal
 
     See also:
         GitHub      https://github.com/m-ama/PyDesigner

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -132,9 +132,12 @@ def main():
                         ' denoising. '
                         'Default: 5,5,5.')
     parser.add_argument('--reslice', metavar='x,y,z',
-                        help='Relices DWI to resolution specified in '
-                        'millimeters (mm). Performing reslicing will '
-                        'skip plotting of SNR curves.')
+                        help='Relices DWI to voxel resolution '
+                        'specified in millimeters (mm) or output '
+                        'dimensions. Performing reslicing will skip '
+                        'plotting of SNR curves. Providing dimensions '
+                        'greater than 9 will swtich from mm voxel '
+                        'reslicing to output image reslicing.')
     parser.add_argument('--interp', action='store_true', default='linear',
                         help='Set the interpolation to use when '
                         'reslicing. Choices are linear (default), ' 
@@ -502,19 +505,28 @@ def main():
     if args.reslice:
         step_count += 1
         reslice_name = 'dwi_reslice'
+        noise_name = 'noisemap_resliced'
         # file names
         reslice_name_full = str(step_count)+ '_' + reslice_name
         nii_reslice = op.join(intermediatepath, reslice_name_full + '.nii')
         mif_reslice = op.join(outpath, reslice_name_full + '.mif')
+        nii_noise = op.join(outpath, noise_name + '.nii')
         # check to see if this already exists
         if not (args.resume and op.exists(nii_reslice)):
-            # run degibbs function
+            # run reslice function on both DWI and noisemap
             mrpreproc.reslice(input=working_path,
                               output=mif_reslice,
-                              voxel=args.reslice,
+                              size=args.reslice,
                               interp=args.interp,
                               nthreads=args.nthreads,
                               force=args.force,
+                              verbose=args.verbose)
+            mrpreproc.reslice(input=nii_noisemap,
+                              output=nii_noise,
+                              size=args.reslice,
+                              interp=args.interp,
+                              nthreads=args.nthreads,
+                              force=True,
                               verbose=args.verbose)
             mrpreproc.miftonii(input=mif_reslice,
                                output=nii_reslice,
@@ -525,6 +537,7 @@ def main():
             # remove old working.mif and replace with new corrected .mif
             os.remove(working_path)
             os.rename(mif_reslice, working_path)
+            os.rename(nii_noise, nii_noisemap)
             # update command history
             cmdtable['reslice'] = mrinfoutil.commandhistory(working_path)[-1]
             cmdtable['HEAD'] = cmdtable['reslice']

--- a/docs/source/reference/pydesigner_args.rst
+++ b/docs/source/reference/pydesigner_args.rst
@@ -28,7 +28,7 @@ preprocessing pipeline, to accomodate all types of datasets.
 
 --extent        Shape of denoising extent matrix, defaults to 5,5,5
 
---reslice       Reslices input DWI and outputs to a specific resolution in mm
+--reslice       Reslices input DWI and outputs to a specific resolution in mm or output dimensions
 
 --interp        The interpolation method to use when resizing
 
@@ -36,7 +36,7 @@ preprocessing pipeline, to accomodate all types of datasets.
 
 --undistort     Undistorts image using a suite of EPI distortion correction, eddy current correction, and co-registration. Does not run EPI correction if reverse phase encoding DWI is absent.
 
---epi N         Speeds up topup if a reverse PE is present; specify the number (integer) of reverse PE direction B0 pairs to use
+--rpe_pairs N   Speeds up topup if a reverse PE is present; specify the number (integer) of reverse PE direction B0 pairs to use
 
 --mask          Computes a brain mask at 0.20 threshold by default
 


### PR DESCRIPTION
PyD can now automatically reslice up to specified 3D image dimensions or voxel size. Any dimension specified over 9 mm gets resliced with `mrresize -size...`, other `mrresize -voxel ...` is used.

There are also additional checks and balances.

Flag `--epi N` has been renamed to `--rpe_pairs N` to avoid confusion.