### PR TITLE
Transpose B0 BVALS in json2fslgrad

### DIFF
--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -157,7 +157,7 @@ def json2fslgrad(path):
         else:
             nDWI = 1
         if nDWI <= 15:
-            bval = np.zeros(nDWI, dtype=int)
+            bval = np.zeros((1, nDWI), dtype=int)
             bvec = np.zeros((3, nDWI), dtype=int)
             fPath = op.splitext(path)[0]
             np.savetxt(op.join(image.getPath(), image.getName() + '.bvec'), 


### PR DESCRIPTION
Produces column vector of BVALs in accordance to FSL gradient scheme, instead of a row vector. Fixes #194 