### PR TITLE
Fix for nthreads issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,27 @@ Changelog
 All notable changes to this project will be documented in this file or
 page
 
+`v1.0_RC2`_
+-----------
+
+Aug 25, 2020
+
+**Added**:
+* References to README.rst
+
+**Changed**:
+
+* The minimum B-value required for FBI (4000) is now inclusive
+  instead of exclusive. This would allow executiong of FBI/FBWM
+  for datasets with b=4000 mm/s^2
+* Convert variable ``nthreads`` to string so ``subproces.run``
+  can recognize the flag
+* Updated Slack permalink in README.rst
+
+**Removed**:
+
+* None
+
 `v1.0_RC1`_
 -----------
 
@@ -153,7 +174,8 @@ Initial port of MATLAB code to Python. 200,000,000,000 BCE
 
 
 .. Links
-.. _v1.0_RC1: https://github.com/m-ama/PyDesigner/releases/tag/v1.0_RC1
+.. _v1.0_RC2: https://github.com/m-ama/PyDesigner/releases/tag/v1.0_RC2
+.. _v1.0_RC1: https://github.com/m-ama/PyDesigner/releases/tag/v1.0-RC1
 .. _v0.32: https://github.com/m-ama/PyDesigner/releases/tag/v0.32
 .. _v0.31: https://github.com/m-ama/PyDesigner/releases/tag/v0.31
 .. _v0.3: https://github.com/m-ama/PyDesigner/releases/tag/v0.3

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ Notable Features
 - **One-shot** preprocessing to parameter extraction
 - **Cross-platform compatibility** between Windows, Mac and Linux using Docker
 - Highly flexible and **easy to use**
+- **Parallel processing** for quicker preprocessing and parameterization
 - **Easy install** with `pip`
 - Input **file-format agnostic** – works with .nii, .nii.gz, .mif and dicoms
 - **Quality control metrics** to evaluate data integrity – SNR graphs, outlier voxels, and head motion
@@ -60,7 +61,7 @@ project’s GitHub repository. Additionally, you may join the `M-AMA
 Slack channel`_ for live support.
 
 .. _Issues: https://github.com/m-ama/PyDesigner/issues
-.. _M-AMA Slack channel: https://join.slack.com/t/m-ama/shared_invite/enQtOTUyOTU0MTQ1OTQxLTQwOGZlMzI4YmY2YTUxOWY2NmYxMjgwM2E4ODdkNmU3MGYyMjFiMThlYTIwOGQyNzEzMTAzYTZmMmMyM2NjNTc
+.. _M-AMA Slack channel: https://m-ama.slack.com/
 
 **System Requirements**
    Parallel processing in PyDesigner scales almost linearly with the
@@ -75,3 +76,21 @@ Slack channel`_ for live support.
    - 16 GB RAM
    - 12 GB free storage
    - Nvidia CUDA-enabled GPU
+
+References
+==========
+
+The PyDesigner software packages is based upon the the references
+listed below. Please be sure to cite them if PyDesigner was used
+in any publications.
+
+1. Jensen JH, Helpern JA, Ramani A, Lu H, Kaczynski K. Diffusional kurtosis imaging: the quantification of non-Gaussian water diffusion by means of MRI. Magn Reson Med 2005;53:1432-1440. doi: 10.1002/mrm.20508 
+2. Jensen JH, Helpern JA. MRI Quantification of non-Gaussian water diffusion by kurtosis analysis. NMR Biomed 2010;23:698-710. doi: 10.1002/nbm.1518 
+3. Fieremans E, Jensen JH, Helpern JA. White matter characterization with diffusional kurtosis imaging. Neuroimage 2011;58:177-188. doi: 10.1016/j.neuroimage.2011.06.006 
+4. Tabesh A, Jensen JH, Ardekani BA, Helpern JA. Estimation of tensors and tensor-derived measures in diffusional kurtosis imaging. Magn Reson Med 2011;65:823-836. doi: 10.1002/mrm.22655 
+5. Glenn GR, Helpern JA, Tabesh A, Jensen JH. Quantitative assessment of diffusional kurtosis anisotropy. NMR Biomed 2015;28:448-459. doi: 10.1002/nbm.3271 
+6. Jensen JH, Glenn GR, Helpern JA. Fiber ball imaging. Neuroimage 2016; 124:824-833. doi: 10.1016/j.neuroimage.2015.09.049 
+7. McKinnon ET, Helpern JA, Jensen JH. Modeling white matter microstructure with fiber ball imaging. Neuroimage 2018;176:11-21. doi: 10.1016/j.neuroimage.2018.04.025 
+8. Ades-Aron B, Veraart J, Kochunov P, McGuire S, Sherman P, Kellner E, Novikov DS, Fieremans E. Evaluation of the accuracy and precision of the diffusion parameter EStImation with Gibbs and NoisE removal pipeline. Neuroimage. 2018;183:532-543. doi: 10.1016/j.neuroimage.2018.07.066 
+9. Moss H, McKinnon ET, Glenn GR, Helpern JA, Jensen JH. Optimization of data acquisition and analysis for fiber ball imaging. Neuroimage 2019;200;690-703. doi: 10.1016/j.neuroimage.2019.07.005
+10. Moss HG, Jensen JH. Optimized rectification of fiber orientation density function. Magn Reson Med. 2020 Jul 25. doi: 10.1002/mrm.28406. Online ahead of print. 

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -257,7 +257,7 @@ class DWI(object):
         """
         idx = np.ones_like(self.grad[:, 3], dtype=bool)
         if self.isfbi():
-            idx = self.grad[:, -1] > th.__minfbibval__
+            idx = self.grad[:, -1] >= th.__minfbibval__
         else:
             raise IndexError('No valid FBI sequence found.')
         return idx

--- a/designer/info.py
+++ b/designer/info.py
@@ -10,7 +10,7 @@ __execdir__ = os.path.basename(
     )
 )
 __packagename__ = 'PyDesigner'
-__version__='v1.0-RC1'
+__version__='v1.0-RC2'
 __author__ = 'PyDesigner developers'
 __copyright__ = 'Copyright 2020, PyDesigner developers, MUSC Advanced Image Analysis (MAMA)'
 __credits__ = [

--- a/designer/preprocessing/mrpreproc.py
+++ b/designer/preprocessing/mrpreproc.py
@@ -70,7 +70,7 @@ def miftonii(input, output, strides='1,2,3,4', nthreads=None,
     if not verbose:
         arg.append('-quiet')
     if not (nthreads is None):
-        arg.extend(['-nthreads', nthreads])
+        arg.extend(['-nthreads', str(nthreads)])
     arg.extend(['-export_grad_fsl',
                 op.splitext(output)[0] + '.bvec',
                 op.splitext(output)[0] + '.bval'])
@@ -150,7 +150,7 @@ def niitomif(input, output, strides='1,2,3,4', nthreads=None,
     if not verbose:
         arg.append('-quiet')
     if not (nthreads is None):
-        arg.extend(['-nthreads', nthreads])
+        arg.extend(['-nthreads', str(nthreads)])
     arg.extend(['-fslgrad',
                 op.splitext(input)[0] + '.bvec',
                 op.splitext(input)[0] + '.bval'])
@@ -222,7 +222,7 @@ def denoise(input, output, noisemap=True, extent='5,5,5', nthreads=None,
     if not verbose:
         arg.append('-quiet')
     if not (nthreads is None):
-        arg.extend(['-nthreads', nthreads])
+        arg.extend(['-nthreads', str(nthreads)])
     if noisemap:
         arg.extend(['-noise', noisemap_path])
     if not (extent is None):
@@ -279,7 +279,7 @@ def degibbs(input, output, nthreads=None, force=False, verbose=False):
     if not verbose:
         arg.append('-quiet')
     if not (nthreads is None):
-        arg.extend(['-nthreads', nthreads])
+        arg.extend(['-nthreads', str(nthreads)])
     arg.extend([input, output])
     completion = subprocess.run(arg)
     if completion.returncode != 0:
@@ -373,7 +373,7 @@ def undistort(input, output, rpe='rpe_header', epib0=1,
     if not verbose:
         arg.append('-quiet')
     if not (nthreads is None):
-        arg.extend(['-nthreads', nthreads])
+        arg.extend(['-nthreads', str(nthreads)])
     # Determine whether half or full sphere sampling
     repol_string = '--repol '
     if util.bvec_is_fullsphere(op.join(outdir, 'dwiec.bvec')):
@@ -633,7 +633,7 @@ def extractbzero(input, output, nthreads=None, force=False,
     if not verbose:
         arg.append('-quiet')
     if not (nthreads is None):
-        arg.extend(['-nthreads', nthreads])
+        arg.extend(['-nthreads', str(nthreads)])
     arg.extend(['-bzero', input, output])
     completion = subprocess.run(arg)
     if completion.returncode != 0:
@@ -747,7 +747,7 @@ def extractnonbzero(input, output, nthreads=None, force=False,
     if not verbose:
         arg.append('-quiet')
     if not (nthreads is None):
-        arg.extend(['-nthreads', nthreads])
+        arg.extend(['-nthreads', str(nthreads)])
     arg.extend(['-no_bzero', input, output])
     completion = subprocess.run(arg)
     if completion.returncode != 0:
@@ -859,7 +859,7 @@ def epiboost(input, output, num=1, nthreads=None, force=False,
     if not verbose:
         arg_epi.append('-quiet')
     if not (nthreads is None):
-        arg_epi.extend(['-nthreads', nthreads])
+        arg_epi.extend(['-nthreads', str(nthreads)])
     arg_epi.extend(['-coord', '3', ','.join(str_extract)])
     arg_epi.extend([fname_bzero, output])
     completion = subprocess.run(arg_epi)
@@ -959,7 +959,7 @@ def reslice(input, output, size, interp='linear',
     if not verbose:
         arg.append('-quiet')
     if not (nthreads is None):
-        arg.extend(['-nthreads', nthreads])
+        arg.extend(['-nthreads', str(nthreads)])
     arg.extend([dim_str, size])
     arg.extend(['-interp', interp])
     arg.extend([input, output])

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -261,7 +261,7 @@ class DWIFile:
 
     def getFull(self):
         """
-        Get the path and name combined for thsi dwifile
+        Get the path and name combined for this dwifile
 
         Returns
         -------

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -782,9 +782,14 @@ def main():
     if not args.nofit:
         # create dwi fitting object
         if not args.nthreads:
-            img = dp.DWI(filetable['HEAD'].getFull())
+            img = dp.DWI(
+                imPath=filetable['HEAD'].getFull(),
+            )
         else:
-            img = dp.DWI(filetable['HEAD'].getFull(), args.nthreads)
+            img = dp.DWI(
+                imPath=filetable['HEAD'].getFull(),
+                nthreads=args.nthreads
+            )
         protocols = img.tensorType()
         print('Protocol(s) detected: {}' .format([x.upper() for x in protocols]))
         # Define filenames

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -639,7 +639,7 @@ def main():
         brainmask_name = 'brain_mask.nii'
         brainmask_out = op.join(outpath, 'brain_mask.nii')
         shutil.copy(args.user_mask, brainmask_out)
-        filetable['mask'] = DWIFile(brainmask_out) 
+        filetable['mask'] = DWIFile(brainmask_out)
 
     #-----------------------------------------------------------------
     # Smooth

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     maintainer=__maintainer__,
     description=__description__,
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type='text/x-rst',
     url=__url__,
     license=__license__,
     include_package_data=True,


### PR DESCRIPTION
This PR fixes issues when the `--nthreads` flag is used. In addition, the lowest B-value for FBI has also been updated to 4000 mm/^s.