### PR TITLE
Update develop to master

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,14 +7,15 @@ page
 `v1.0_RC3`_
 -----------
 
-Sep 3, 2020
+Sep 21, 2020
 
 **Added**:
 * FBI fODF map for FBI tractography. Users may use MRTrix3
   to further process this file.
 * Variable maximum spherical harmonic degree to improve
-  robustness of FBI fit. This was fixed at 6 previous, but
-  is able to vary from 2 to 8 now. This is based on
+  robustness of FBI fit. This was fixed at 6 previous, but has
+  been defaulted to 6 now. Users may change l_max with the
+  ``-l_max n`` flag. This is based on
   information found at https://mrtrix.readthedocs.io/en/dev/concepts/sh_basis_lmax.html
 
 **Changed**:

--- a/designer/fitting/dwipy.py
+++ b/designer/fitting/dwipy.py
@@ -1055,29 +1055,38 @@ class DWI(object):
         from the information posted at
         https://mrtrix.readthedocs.io/en/dev/concepts/sh_basis_lmax.html
 
+        This function runs successfully only if input
+        DWI is an FBI or HARDI acquisition.
+
         Returns
         -------
-        l_max : int
+        int
             l_max suitable for DWI
         """
+        if not self.isfbi():
+            raise Exception('Input DWI is not an '
+        'FBI or HARDI acquisiton. Cannot compute '
+        'l_max.')
         bt_unique = np.unique(self.grad[:, -1])
-        min_vols = min([np.count_nonzero(self.grad[:, -1] == x) for x in bt_unique if x > 0])
-        l_max = 2
-        if min_vols <= 15:
-            l_max = 4
-        elif min_vols <= 28:
-            l_max = 6
-        else:
-            l_max = 8
-        return l_max
+        fbi_vols = np.count_nonzero(self.grad[self.idxfbi(), -1])
+        l_max = 0
+        vols = (l_max + 1) * (l_max/2 + 1)
+        while vols <= fbi_vols:
+            l_max += 2
+            vols = (l_max + 1) * (l_max/2 + 1)
+        return l_max - 2
 
-    def fbi(self, fbwm=True, rectify=True):
+    def fbi(self, l_max=6, fbwm=True, rectify=True):
         """
         Perform fiber ball imaging (FBI) and FBI white matter model
         (FBWM) analyses
 
         Parameters
         ----------
+        l_max : int
+            Maximum spherical harmonic degree specified as an even
+            integer
+            (Default: 6)
         fbwm : bool
             Perform FBWM parameterization if True
             (Default: True)
@@ -1464,11 +1473,19 @@ class DWI(object):
             return zeta, faa, clm, min_awf, Da, De_mean, De_ax, De_rad, De_fa, min_cost, min_cost_fn
         #--------------------FUNCTION SEPARATOR-----------------------
 
-
         if fbwm and not hasattr(self, 'dt'):
             raise Exception('Cannot compute FBWM parameters '
         'without running diffusion tensor fitting first. '
         'Please run DWI.fit(constraints) before running DWI.fbi().')
+        if l_max % 2 != 0:
+            raise Exception('Please provide l_max as a postive '
+        'and even integer')
+        if l_max > self.optimal_lmax():
+            print('[WARNING]: l_max value provided ({}) is '
+            'more than that supported by DWI ({}). Reverting '
+            'to l_max = {}'.format(l_max, self.optimal_lmax(),
+            self.optimal_lmax()))
+            l_max = self.optimal_lmax()
         img = self.img
         bt_unique = np.unique(self.grad[:, -1])
         order = self.optimal_lmax()
@@ -1477,7 +1494,7 @@ class DWI(object):
         b0 = vectorize(b0, self.mask)
         img = vectorize(img, self.mask)
         # Create shperical harmonic (SH) base set
-        degs = np.arange(order + 1, dtype=int)
+        degs = np.arange(l_max + 1, dtype=int)
         l_tot = 2*degs + 1 # total harmonics in the degree
         l_num = 2 * degs[::2] + 1 # how many per degree (evens only)
         harmonics = []

--- a/docs/source/reference/pydesigner_args.rst
+++ b/docs/source/reference/pydesigner_args.rst
@@ -24,7 +24,7 @@ preprocessing pipeline, to accomodate all types of datasets.
 
 -s, --standard  Runs the recommended preprocessing pipeline in order: denoise, degibbs, undistort, brain mask, smooth, rician
 
---denoise       Denoises input DWI
+-n, --denoise       Denoises input DWI
 
 --extent        Shape of denoising extent matrix, defaults to 5,5,5
 
@@ -32,11 +32,11 @@ preprocessing pipeline, to accomodate all types of datasets.
 
 --interp        The interpolation method to use when resizing
 
---degibbs       Corrects Gibb’s ringing
+-g, --degibbs       Corrects Gibb’s ringing
 
---undistort     Undistorts image using a suite of EPI distortion correction, eddy current correction, and co-registration. Does not run EPI correction if reverse phase encoding DWI is absent.
+-u, --undistort     Undistorts image using a suite of EPI distortion correction, eddy current correction, and co-registration. Does not run EPI correction if reverse phase encoding DWI is absent.
 
---rpe_pairs N   Speeds up topup if a reverse PE is present; specify the number (integer) of reverse PE direction B0 pairs to use
+--rpe_pairs n   Speeds up topup if a reverse PE is present; specify the number (integer) of reverse PE direction B0 pairs to use
 
 --mask          Computes a brain mask at 0.20 threshold by default
 
@@ -44,11 +44,11 @@ preprocessing pipeline, to accomodate all types of datasets.
 
 --user_mask     Provide path to user-generated brain mask in NifTi (.nii) format
 
---smooth        Smooths DWI data at a default FWHM of 1.25
+-z, --smooth        Smooths DWI data at a default FWHM of 1.25
 
 --fwhm          Specify the FWHM at which to smooth, defaults to 1.25
 
---rician        Corrects Rician bias
+-r, --rician        Corrects Rician bias
 
 Diffusion Tensor Control
 ------------------------
@@ -70,13 +70,20 @@ with the following flags.
 
 --median            Performs post processing median filter of final DTI/DKI maps. **WARNING: Use on a case-by-case basis for bad data only. When applied, the filter alters the values of most voxels, so it should be used with caution and avoided when data quality is otherwise adequate. While maps appear visually soother with this flag on, they may nonetheless be less accurate**
 
+Fiber Ball Imaging (FBI) Control
+--------------------------------
+
+FBI parameters may be fine-tuned with the following flags.
+
+--l_max n   Maximum spherical harmonic degree used in spherical harmonic expansion for fODF calculation
+
 Pipeline Control
 ----------------
 
 These are more general pipeline flags that interface directly with the
 user or machine.
 
---nthreads N    Specify number of CPU workers to use in processing, defaults to all physically available workers
+--nthreads n    Specify number of CPU workers to use in processing, defaults to all physically available workers
 
 --resume        Resumes preprocessing from an aborted or partial previous run
 


### PR DESCRIPTION
* Convert AWF array to float

* Update input file check in dwipy

* Fixed dockerfile bugs (#202)

* Update files to delete

* Update Changelog

* Update PyDesigner version info

* Update des2dke B0 name

* WMTI Calculation Fix (#204)

* Add intra- and extra-axonal diffusivities to WMTI

* Convert `json2fslgrad` from method to func

* Update CHANGELOG

* Update v0.31>>v0.32

* Update doc table of file outputs

* Update README image size

* Change WMTI file names

* Change filenames again

* Minor WMTI bugfixes

* Transpose B0 BVALS in json2fslgrad (#206)

* Update changelog (#207)

* Update PyD to DKE conversion script (#209)

* Rename Extras to extras

* Init FT parameter file

* Allow FWHM res change in DKE param file

* Update PyD to DKE conversion script

* Update changelog

* FBI and FBWM Calculation (#215)

* Add functions to differentiate DTI/DKI and FBI protocols

* Update `dwipreproc` command to `dwifslpreproc`

* Update changelog

* Extend compatibility with pre- and post-release mrtrix3

Automatically determines whether to run `dwipreproc` or `dwifslpreproc`, depending on which the user has installed.

* Update CHANGELOG

* Add mask staging to dwipy

* Add spherical grid to dwidirs

* Update list of thresholds

* Init function dwipi.fbi()

* Complete implementation of base FBI functions

* Expand FBI compatibility with DTI/DKI

* Add FBWM protocol tensor type

* Fix output fname for FBI De_mean

* Update requirements with package version specifications

* Update constrained tensor solver for compatibility with CVXPY > 1.1.0

This commit uses the recommended matrix-multiplication symbol.

* Add FBI debugging scripts

* Modularize FBI rectification

* Fix spherical harmonic expansion for half-sphere

* Change minimum zero to 10E-8

* Minor dwipy fixes

* Fix and modularize cost function

* Fix bugs in cost function

* Fix issues with plotting

* Remove systemtools and MKL fix

* Add bval extraction for outlier map

* Update version info

* Update CHANGELOG

* Update output filenames

* Update README

* Add minimum module requirements

* Update doc version to v1.0-RC1

* Update documentation

* Remove debug files

* Fix for nthreads issue (#217)

* Change min B-value for FBI to be inclusive

* Convert `nthreads` from int to str

* Update main()

* Fix typo in docstring

* Update README.rst

* Restore missing line in main()

* Update setup indo

* Update CHANGELOG

* Fix `--nthreads` and FBI issues (#218) (#219)

* Convert AWF array to float

* Update input file check in dwipy

* Fixed dockerfile bugs (#202)

* Update files to delete

* Update Changelog

* Update PyDesigner version info

* Update des2dke B0 name

* WMTI Calculation Fix (#204)

* Add intra- and extra-axonal diffusivities to WMTI

* Convert `json2fslgrad` from method to func

* Update CHANGELOG

* Update v0.31>>v0.32

* Update doc table of file outputs

* Update README image size

* Change WMTI file names

* Change filenames again

* Minor WMTI bugfixes

* Transpose B0 BVALS in json2fslgrad (#206)

* Update changelog (#207)

* Update PyD to DKE conversion script (#209)

* Rename Extras to extras

* Init FT parameter file

* Allow FWHM res change in DKE param file

* Update PyD to DKE conversion script

* Update changelog

* FBI and FBWM Calculation (#215)

* Add functions to differentiate DTI/DKI and FBI protocols

* Update `dwipreproc` command to `dwifslpreproc`

* Update changelog

* Extend compatibility with pre- and post-release mrtrix3

Automatically determines whether to run `dwipreproc` or `dwifslpreproc`, depending on which the user has installed.

* Update CHANGELOG

* Add mask staging to dwipy

* Add spherical grid to dwidirs

* Update list of thresholds

* Init function dwipi.fbi()

* Complete implementation of base FBI functions

* Expand FBI compatibility with DTI/DKI

* Add FBWM protocol tensor type

* Fix output fname for FBI De_mean

* Update requirements with package version specifications

* Update constrained tensor solver for compatibility with CVXPY > 1.1.0

This commit uses the recommended matrix-multiplication symbol.

* Add FBI debugging scripts

* Modularize FBI rectification

* Fix spherical harmonic expansion for half-sphere

* Change minimum zero to 10E-8

* Minor dwipy fixes

* Fix and modularize cost function

* Fix bugs in cost function

* Fix issues with plotting

* Remove systemtools and MKL fix

* Add bval extraction for outlier map

* Update version info

* Update CHANGELOG

* Update output filenames

* Update README

* Add minimum module requirements

* Update doc version to v1.0-RC1

* Update documentation

* Remove debug files

* Fix for nthreads issue (#217)

* Change min B-value for FBI to be inclusive

* Convert `nthreads` from int to str

* Update main()

* Fix typo in docstring

* Update README.rst

* Restore missing line in main()

* Update setup indo

* Update CHANGELOG

* Change fname of FBI AWF (#220)

* Merge master into develop (#222)

* Fix `--nthreads` and FBI issues (#218)

* Convert AWF array to float

* Update input file check in dwipy

* Fixed dockerfile bugs (#202)

* Update files to delete

* Update Changelog

* Update PyDesigner version info

* Update des2dke B0 name

* WMTI Calculation Fix (#204)

* Add intra- and extra-axonal diffusivities to WMTI

* Convert `json2fslgrad` from method to func

* Update CHANGELOG

* Update v0.31>>v0.32

* Update doc table of file outputs

* Update README image size

* Change WMTI file names

* Change filenames again

* Minor WMTI bugfixes

* Transpose B0 BVALS in json2fslgrad (#206)

* Update changelog (#207)

* Update PyD to DKE conversion script (#209)

* Rename Extras to extras

* Init FT parameter file

* Allow FWHM res change in DKE param file

* Update PyD to DKE conversion script

* Update changelog

* FBI and FBWM Calculation (#215)

* Add functions to differentiate DTI/DKI and FBI protocols

* Update `dwipreproc` command to `dwifslpreproc`

* Update changelog

* Extend compatibility with pre- and post-release mrtrix3

Automatically determines whether to run `dwipreproc` or `dwifslpreproc`, depending on which the user has installed.

* Update CHANGELOG

* Add mask staging to dwipy

* Add spherical grid to dwidirs

* Update list of thresholds

* Init function dwipi.fbi()

* Complete implementation of base FBI functions

* Expand FBI compatibility with DTI/DKI

* Add FBWM protocol tensor type

* Fix output fname for FBI De_mean

* Update requirements with package version specifications

* Update constrained tensor solver for compatibility with CVXPY > 1.1.0

This commit uses the recommended matrix-multiplication symbol.

* Add FBI debugging scripts

* Modularize FBI rectification

* Fix spherical harmonic expansion for half-sphere

* Change minimum zero to 10E-8

* Minor dwipy fixes

* Fix and modularize cost function

* Fix bugs in cost function

* Fix issues with plotting

* Remove systemtools and MKL fix

* Add bval extraction for outlier map

* Update version info

* Update CHANGELOG

* Update output filenames

* Update README

* Add minimum module requirements

* Update doc version to v1.0-RC1

* Update documentation

* Remove debug files

* Fix for nthreads issue (#217)

* Change min B-value for FBI to be inclusive

* Convert `nthreads` from int to str

* Update main()

* Fix typo in docstring

* Update README.rst

* Restore missing line in main()

* Update setup indo

* Update CHANGELOG

* Change fname of FBI AWF (#221)

* Convert AWF array to float

* Update input file check in dwipy

* Fixed dockerfile bugs (#202)

* Update files to delete

* Update Changelog

* Update PyDesigner version info

* Update des2dke B0 name

* WMTI Calculation Fix (#204)

* Add intra- and extra-axonal diffusivities to WMTI

* Convert `json2fslgrad` from method to func

* Update CHANGELOG

* Update v0.31>>v0.32

* Update doc table of file outputs

* Update README image size

* Change WMTI file names

* Change filenames again

* Minor WMTI bugfixes

* Transpose B0 BVALS in json2fslgrad (#206)

* Update changelog (#207)

* Update PyD to DKE conversion script (#209)

* Rename Extras to extras

* Init FT parameter file

* Allow FWHM res change in DKE param file

* Update PyD to DKE conversion script

* Update changelog

* FBI and FBWM Calculation (#215)

* Add functions to differentiate DTI/DKI and FBI protocols

* Update `dwipreproc` command to `dwifslpreproc`

* Update changelog

* Extend compatibility with pre- and post-release mrtrix3

Automatically determines whether to run `dwipreproc` or `dwifslpreproc`, depending on which the user has installed.

* Update CHANGELOG

* Add mask staging to dwipy

* Add spherical grid to dwidirs

* Update list of thresholds

* Init function dwipi.fbi()

* Complete implementation of base FBI functions

* Expand FBI compatibility with DTI/DKI

* Add FBWM protocol tensor type

* Fix output fname for FBI De_mean

* Update requirements with package version specifications

* Update constrained tensor solver for compatibility with CVXPY > 1.1.0

This commit uses the recommended matrix-multiplication symbol.

* Add FBI debugging scripts

* Modularize FBI rectification

* Fix spherical harmonic expansion for half-sphere

* Change minimum zero to 10E-8

* Minor dwipy fixes

* Fix and modularize cost function

* Fix bugs in cost function

* Fix issues with plotting

* Remove systemtools and MKL fix

* Add bval extraction for outlier map

* Update version info

* Update CHANGELOG

* Update output filenames

* Update README

* Add minimum module requirements

* Update doc version to v1.0-RC1

* Update documentation

* Remove debug files

* Fix for nthreads issue (#217)

* Change min B-value for FBI to be inclusive

* Convert `nthreads` from int to str

* Update main()

* Fix typo in docstring

* Update README.rst

* Restore missing line in main()

* Update setup indo

* Update CHANGELOG

* Fix `--nthreads` and FBI issues (#218) (#219)

* Convert AWF array to float

* Update input file check in dwipy

* Fixed dockerfile bugs (#202)

* Update files to delete

* Update Changelog

* Update PyDesigner version info

* Update des2dke B0 name

* WMTI Calculation Fix (#204)

* Add intra- and extra-axonal diffusivities to WMTI

* Convert `json2fslgrad` from method to func

* Update CHANGELOG

* Update v0.31>>v0.32

* Update doc table of file outputs

* Update README image size

* Change WMTI file names

* Change filenames again

* Minor WMTI bugfixes

* Transpose B0 BVALS in json2fslgrad (#206)

* Update changelog (#207)

* Update PyD to DKE conversion script (#209)

* Rename Extras to extras

* Init FT parameter file

* Allow FWHM res change in DKE param file

* Update PyD to DKE conversion script

* Update changelog

* FBI and FBWM Calculation (#215)

* Add functions to differentiate DTI/DKI and FBI protocols

* Update `dwipreproc` command to `dwifslpreproc`

* Update changelog

* Extend compatibility with pre- and post-release mrtrix3

Automatically determines whether to run `dwipreproc` or `dwifslpreproc`, depending on which the user has installed.

* Update CHANGELOG

* Add mask staging to dwipy

* Add spherical grid to dwidirs

* Update list of thresholds

* Init function dwipi.fbi()

* Complete implementation of base FBI functions

* Expand FBI compatibility with DTI/DKI

* Add FBWM protocol tensor type

* Fix output fname for FBI De_mean

* Update requirements with package version specifications

* Update constrained tensor solver for compatibility with CVXPY > 1.1.0

This commit uses the recommended matrix-multiplication symbol.

* Add FBI debugging scripts

* Modularize FBI rectification

* Fix spherical harmonic expansion for half-sphere

* Change minimum zero to 10E-8

* Minor dwipy fixes

* Fix and modularize cost function

* Fix bugs in cost function

* Fix issues with plotting

* Remove systemtools and MKL fix

* Add bval extraction for outlier map

* Update version info

* Update CHANGELOG

* Update output filenames

* Update README

* Add minimum module requirements

* Update doc version to v1.0-RC1

* Update documentation

* Remove debug files

* Fix for nthreads issue (#217)

* Change min B-value for FBI to be inclusive

* Convert `nthreads` from int to str

* Update main()

* Fix typo in docstring

* Update README.rst

* Restore missing line in main()

* Update setup indo

* Update CHANGELOG

* Change fname of FBI AWF (#220)

* Output fODF map (#223)

* Remove GitHub workflows

* Update des2dke.m for protocols containing FBI

* Update des2dke.m console prints

* Change progress bar text

* Add fODF map and variable l_max

* Update documentation

* Update into to v1.0-RC3

* Improve FBI fit robustness (#225)

* Change how l_max is computed and set

* Remove redundant print statement

* Update documentation

* Update flag documentation