### PR TITLE
Fix typo in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include designer/fitting/*.csv
-include desiger/tractography/*.mat
+include designer/tractography/*.mat
 global-exclude *.py[cod] __pycache__ *.so


### PR DESCRIPTION
Fixes error `FileNotFoundError: [Errno 2] No such file or directory: '/home/cbiadmin/.conda/envs/dmri/lib/python3.7/site-packages/designer/tractography/odfs.mat'`