### PR TITLE
Fix b-value rounding to integer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,24 @@ Changelog
 All notable changes to this project will be documented in this file or
 page
 
+`v1.0-RC9`_
+-----------
+
+Mar 16, 2021
+
+**Added**:
+
+* None
+
+**Changed**
+
+* B-values are first rounded to a float insted of integer directly to
+  prevent errors in preprocessing
+
+**Removed**
+
+* None
+
 `v1.0-RC8`_
 -----------
 
@@ -124,6 +142,7 @@ Sep 22, 2020
 Sep 21, 2020
 
 **Added**:
+
 * FBI fODF map for FBI tractography. Users may use MRTrix3
   to further process this file.
 * Variable maximum spherical harmonic degree to improve
@@ -312,6 +331,7 @@ Initial port of MATLAB code to Python. 200,000,000,000 BCE
 
 .. Links
 
+.. _v1.0-RC9: https://github.com/m-ama/PyDesigner/releases/tag/v1.0-RC9
 .. _v1.0-RC8: https://github.com/m-ama/PyDesigner/releases/tag/v1.0-RC8
 .. _v1.0-RC7: https://github.com/m-ama/PyDesigner/releases/tag/v1.0-RC7
 .. _v1.0-RC6: https://github.com/m-ama/PyDesigner/releases/tag/v1.0-RC6

--- a/designer/info.py
+++ b/designer/info.py
@@ -10,7 +10,7 @@ __execdir__ = os.path.basename(
     )
 )
 __packagename__ = 'PyDesigner'
-__version__='v1.0-RC8'
+__version__='v1.0-RC9'
 __author__ = 'PyDesigner developers'
 __copyright__ = 'Copyright 2020, PyDesigner developers, MUSC Advanced Image Analysis (MAMA)'
 __credits__ = [

--- a/designer/preprocessing/mrinfoutil.py
+++ b/designer/preprocessing/mrinfoutil.py
@@ -440,8 +440,7 @@ def max_shell(path):
     console = [s.split(' ') for s in console]
     console = [item for sublist in console for item in sublist]
     console = list(filter(None, console))
-    console = [round(int(s)) for s in console]
-    print(console)
+    console = [int(round(float(s))) for s in console]
     return max(console)
 
 def is_fullsphere(path):


### PR DESCRIPTION
This PR fixes an issue where b-values were being rounded directly to integers, which often led to errors i.e. a b-value 999.9999 instead of 1000 would stop preprocessing.