### PR TITLE
Introduce CSF-masked smoothing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,30 @@ Changelog
 All notable changes to this project will be documented in this file or
 page
 
+`v1.0-RC11`_
+------------
+
+TBA
+
+**Added**:
+
+* CSF excluded smoothing to minimize partial volume effect (PVE).
+  Two methods to do this have been implemented - (1) `-cf or --csf_fsl`
+  using FSL FAST segmentation, and (2) `-cd or --csf_adc n` using
+  pseudo-ADC threshold of more than 2 (ADC > 2).
+
+* Various other support functions such as `mrpreproc.csfmask()` and
+  `mrinfoutil.shells()` to support CSF masking. These functions can
+  also be used for other applications
+
+**Changed**
+
+* Overhaul of preprocessing.smoothing to enable NaN-smoothing
+
+**Removed**
+
+* None
+
 `v1.0-RC10`_
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,13 @@ Slack channel`_ for live support.
    - 12 GB free storage
    - Nvidia CUDA-enabled GPU
 
+Cite PyDesigner
+===============
+Please include the following citation if you used PyDesigner in your
+work or publication:
+
+Siddhartha Dhiman, Joshua B Teves, Kathryn E Thorn, Emilie T McKinnon, Hunter G Moss, Vitria Adisetiyo, Benjamin Ades-Aron, Jelle Veraart, Jenny Chen, Els Fieremans, Andreana Benitez, Joseph A Helpern, Jens H Jensen. PyDesigner: A Pythonic Implementation of the DESIGNER Pipeline for Diffusion Tensor and Diffusional Kurtosis Imaging. bioRxiv 2021.10.20.465189. doi: https://doi.org/10.1101/2021.10.20.465189
+
 References
 ==========
 

--- a/designer/preprocessing/mrinfoutil.py
+++ b/designer/preprocessing/mrinfoutil.py
@@ -354,7 +354,7 @@ def pescheme(path):
         pe_scheme.append(nums)
     return pe_scheme
 
-def num_shells(path):
+def shells(path):
     """
     Returns the number of b-value shells detected in input file
 
@@ -396,6 +396,32 @@ def num_shells(path):
     console = [s.split(' ') for s in console]
     console = [item for sublist in console for item in sublist]
     console = list(filter(None, console))
+    console = [int(x) for x in console]
+    return console
+
+def num_shells(path):
+    """
+    Returns the number of b-value shells detected in input file
+
+    Parameters
+    ----------
+    path : str
+        Path to input image or directory
+
+    Returns
+    -------
+    int
+        Number of shells
+    """
+    if not op.exists(path):
+        raise OSError('Input path does not exist. Please ensure that the '
+                      'folder or file specified exists.')
+    ftype = format(path)
+    if ftype != 'MRtrix':
+        raise IOError('This function only works with MRtrix (.mif) '
+                      'formatted filetypes. Please ensure that the input '
+                      'filetype meets this requirement')
+    console = shells(path)
     return len(console)
 
 def max_shell(path):

--- a/designer/preprocessing/mrpreproc.py
+++ b/designer/preprocessing/mrpreproc.py
@@ -494,8 +494,8 @@ def brainmask(input, output, thresh=0.25, nthreads=None, force=False,
     os.remove(tmp_brain)
     os.rename(op.join(outdir, mask + '_mask.nii'), output)
 
-def csfmask(input, output, thresh=0.25, nthreads=None, force=False,
-              verbose=False):
+def csfmask(input, output, method='fsl', coeff=2, thresh=0.25,
+            nthreads=None, force=False, verbose=False):
     """
     Creates a cerebral spinal fluid (CSF) mask from FSL's FAST tool.
 
@@ -505,7 +505,14 @@ def csfmask(input, output, thresh=0.25, nthreads=None, force=False,
         Path to input .mif file
     output : str
         Path to output .nii CSF mask file
-    thresh : float
+    method : str, optional
+        Define method to use for computing a CSF mask. `'fsl'` relies
+        on FSL FAST segmentation, and `adc` uses pseudo-diffusion
+        coefficient more than 2 (default) to compute a mask
+    coeff : float, optional
+        Diffusion coefficient to use in thresholding a pseudo-diffusion
+        map to estimate CSF (Default: 2)
+    thresh : float, optional
         BET threshold ranging from 0 to 1 (Default: 0.25)
     nthreads : int, optional
         Specify the number of threads to use in processing
@@ -541,98 +548,152 @@ def csfmask(input, output, thresh=0.25, nthreads=None, force=False,
                         'or False.')
     if not isinstance(verbose, bool):
         raise Exception('Please specify whether verbose is True or False.')
-    # Read FSL NifTi output format and change it if not '.nii'
-    fsl_suffix = os.getenv('FSLOUTPUTTYPE')
-    if fsl_suffix is None:
-        raise OSError('Unable to determine system environment variable '
-                      'FSF_OUTPUT_FORMAT. Ensure that FSL is installed '
-                      'correctly.')
-    if fsl_suffix == 'NIFTI_GZ':
-        os.environ['FSLOUTPUTTYPE'] = 'NIFTI'
-    f_suffix = '.nii'
     outdir = op.dirname(output)
-    B0_nan = op.join(outdir, 'B0_nan' + f_suffix)
-    path_brain = op.join(outdir, 'brain')
-    path_tissue = op.join(outdir, 'tissue')
+    if 'fsl' in method:
+        # Read FSL NifTi output format and change it if not '.nii'
+        fsl_suffix = os.getenv('FSLOUTPUTTYPE')
+        if fsl_suffix is None:
+            raise OSError('Unable to determine system environment variable '
+                        'FSF_OUTPUT_FORMAT. Ensure that FSL is installed '
+                        'correctly.')
+        if fsl_suffix == 'NIFTI_GZ':
+            os.environ['FSLOUTPUTTYPE'] = 'NIFTI'
+        f_suffix = '.nii'
+        B0_nan = op.join(outdir, 'B0_nan' + f_suffix)
+        path_brain = op.join(outdir, 'brain')
+        path_tissue = op.join(outdir, 'tissue')
 
-    # Extract averaged B0 from DWI
-    extractmeanbzero(input=input,
-                        output=B0_nan,
-                        nthreads=nthreads,
-                        force=force,
-                        verbose=verbose)
-    # Compute brain mask
-    arg_mask = ['bet', B0_nan, path_brain, '-m', '-f', str(thresh)]
-    completion = subprocess.run(arg_mask)
-    if completion.returncode != 0:
-        raise Exception('Unable to compute brain mask from B0. See above '
-                        'for errors')
-    arg = [
-        'fast'
-    ]
-    if verbose:
-        arg.append('-v')
-    arg.extend([
-        '-n', '4',
-        '-t', '2',
-        '-o', path_tissue,
-        path_brain + f_suffix
-    ])
-    completion = subprocess.run(arg)
-    if completion.returncode != 0:
-        raise Exception('FSL FAST segmentation of brain tissue failed. '
-                        'See above for errors.')
-    csfclass = []
-    for i in range(4):
+        # Extract averaged B0 from DWI
+        extractmeanbzero(input=input,
+                            output=B0_nan,
+                            nthreads=nthreads,
+                            force=force,
+                            verbose=verbose)
+        # Compute brain mask
+        arg_mask = ['bet', B0_nan, path_brain, '-m', '-f', str(thresh)]
+        completion = subprocess.run(arg_mask)
+        if completion.returncode != 0:
+            raise Exception('Unable to compute brain mask from B0. See above '
+                            'for errors')
+        arg = [
+            'fast'
+        ]
+        if verbose:
+            arg.append('-v')
+        arg.extend([
+            '-n', '4',
+            '-t', '2',
+            '-o', path_tissue,
+            path_brain + f_suffix
+        ])
+        completion = subprocess.run(arg)
+        if completion.returncode != 0:
+            raise Exception('FSL FAST segmentation of brain tissue failed. '
+                            'See above for errors.')
+        csfclass = []
+        for i in range(4):
+            arg = [
+                'fslmaths',
+                path_tissue + '_pve_' + str(i) + f_suffix,
+                '-thr', '0.95',
+                '-bin', path_tissue + '_pve_thr_' + str(i) + f_suffix
+            ]
+            completion = subprocess.run(arg)
+            if completion.returncode != 0:
+                raise Exception('FSLMATHS tissue thresholding failed. '
+                                'See above for errors.')
+            arg = [
+                'fslstats',
+                path_brain + '.nii',
+                '-k', path_tissue + '_pve_thr_' + str(i) + f_suffix,
+                '-P', '95'
+            ]
+            completion = subprocess.run(arg, stdout=subprocess.PIPE)
+            if completion.returncode != 0:
+                raise Exception('FSLSTATS tissue thresholding failed. '
+                                'See above for errors.')
+            console = str(completion.stdout).split('\\n')[0]
+            console = console.split('b')[-1]
+            console = console.replace("'", "")
+            csfclass.append(float(console))
+        csfind = np.argmax(csfclass)
         arg = [
             'fslmaths',
-            path_tissue + '_pve_' + str(i) + f_suffix,
-            '-thr', '0.95',
-            '-bin', path_tissue + '_pve_thr_' + str(i) + f_suffix
+            path_tissue + '_pve_' + str(csfind) + f_suffix,
+            '-thr', '0.7',
+            '-bin',
+            # '-mul', '-1',
+            # '-add', '1',
+            '-mul',
+            path_brain + '_mask' + f_suffix,
+            output
         ]
         completion = subprocess.run(arg)
         if completion.returncode != 0:
-            raise Exception('FSLMATHS tissue thresholding failed. '
+            raise Exception('Unable to create CSF mask. '
                             'See above for errors.')
-        arg = [
-            'fslstats',
-            path_brain + '.nii',
-            '-k', path_tissue + '_pve_thr_' + str(i) + f_suffix,
-            '-P', '95'
-        ]
-        completion = subprocess.run(arg, stdout=subprocess.PIPE)
+        # Remove intermediate files
+        os.remove(B0_nan)
+        os.remove(op.join(outdir, path_brain + f_suffix))
+        for i in range(4):
+            os.remove(path_tissue + '_pve_' + str(i) + f_suffix)
+            os.remove(path_tissue + '_pve_thr_' + str(i) + f_suffix)
+        os.remove(path_tissue + '_mixeltype' + f_suffix)
+        os.remove(path_tissue + '_pveseg' + f_suffix)
+        os.remove(path_tissue + '_seg' + f_suffix)
+    if 'adc' in method:
+        # Get list of b-values
+        bvals = mrinfoutil.shells(input)
+        # Find index of shell closest to b=1000
+        idx = min(range(len(bvals)), key=lambda i: abs(bvals[i]-1000))
+        # Specify file paths
+        path_b0 = op.join(outdir, 'S0.mif')
+        path_shell = op.join(outdir, 'S1000.mif')
+        # Extract mean B
+        # Extract averaged B0 from DWI
+        extractmeanbzero(
+            input=input,
+            output=path_b0,
+            nthreads=nthreads,
+            force=force,
+            verbose=verbose)
+        # Extract mean of indexed b=1000 shell
+        extractmeanshell(
+            input=input,
+            output=path_shell,
+            shell=bvals[idx],
+            nthreads=nthreads,
+            force=force,
+            verbose=verbose
+        )
+        # Use the formula D_pseudo = ln(S0/S1000)/B1000 > 2 to compute
+        # brain mask based on pseudo-ADC
+        arg = ['mrcalc']
+        if force:
+            arg.append('-force')
+        if not verbose:
+            arg.append('-quiet')
+        if not (nthreads is None):
+            arg.extend(['-nthreads', str(nthreads)])
+        arg.extend(
+            [
+                path_b0,
+                path_shell,
+                '-div',
+                '-log',
+                str(bvals[idx]/1000),
+                '-div',
+                str(coeff),
+                '-gt',
+                output
+            ]
+        )
+        completion = subprocess.run(arg)
         if completion.returncode != 0:
-            raise Exception('FSLSTATS tissue thresholding failed. '
+            raise Exception('Unable to compute pseudo ADC. '
                             'See above for errors.')
-        console = str(completion.stdout).split('\\n')[0]
-        console = console.split('b')[-1]
-        console = console.replace("'", "")
-        csfclass.append(float(console))
-    csfind = np.argmax(csfclass)
-    arg = [
-        'fslmaths',
-        path_tissue + '_pve_' + str(csfind) + f_suffix,
-        '-thr', '0.7',
-        '-bin',
-        '-mul', '-1',
-        '-add', '1',
-        '-mul',
-        path_brain + '_mask' + f_suffix,
-        output
-    ]
-    completion = subprocess.run(arg)
-    if completion.returncode != 0:
-        raise Exception('Unable to create CSF mask. '
-                        'See above for errors.')
-    # Remove intermediate files
-    os.remove(B0_nan)
-    os.remove(op.join(outdir, path_brain + f_suffix))
-    for i in range(4):
-        os.remove(path_tissue + '_pve_' + str(i) + f_suffix)
-        os.remove(path_tissue + '_pve_thr_' + str(i) + f_suffix)
-    os.remove(path_tissue + '_mixeltype' + f_suffix)
-    os.remove(path_tissue + '_pveseg' + f_suffix)
-    os.remove(path_tissue + '_seg' + f_suffix)
+        os.remove(path_b0)
+        os.remove(path_shell)
 
 def smooth(input, output, csfname=None, fwhm=1.25, size=5):
     """
@@ -902,6 +963,140 @@ def extractnonbzero(input, output, nthreads=None, force=False,
     if completion.returncode != 0:
         raise Exception('Unable to extract B0s from DWI for computation '
                         'of brain mask. See above for errors.')
+
+def extractshell(input, output, shell, nthreads=None, force=False,
+              verbose=False):
+    """
+    Extracts specified shell from an input mif file.
+
+    Parameters
+    ----------
+    input : str
+        Path to input .mif file
+    output : str
+        Path to output .mif file
+    shell : int
+        Approximate b-value to extract
+    nthreads : int, optional
+        Specify the number of threads to use in processing
+        (Default: all available threads)
+    force : bool, optional
+        Force overwrite of output files if pre-existing
+        (Default:False)
+    verbose : bool, optional
+        Specify whether to print console output (Default: False)
+
+    Returns
+    -------
+    None; writes out file
+    """
+    if not op.exists(input):
+        raise OSError('Input path does not exist. Please ensure that '
+                      'the folder or file specified exists.')
+    if not op.exists(op.dirname(output)):
+        raise OSError('Specifed directory for output file {} does not '
+                      'exist. Please ensure that this is a valid '
+                      'directory.'.format(op.dirname(output)))
+    if not isinstance(shell, int):
+        raise Exception('Please specify the shell to extract as an '
+                        'integer.')
+    if shell < 0:
+        raise Exception('Please specify the shell to extract as a '
+                        'positive (more than 0) integer.')
+    if not (nthreads is None):
+        if not isinstance(nthreads, int):
+            raise Exception('Please specify the number of threads as an '
+                            'integer.')
+    if not isinstance(force, bool):
+        raise Exception('Please specify whether forced overwrite is True '
+                        'or False.')
+    if not isinstance(verbose, bool):
+        raise Exception('Please specify whether verbose is True or False.')
+    arg = ['dwiextract']
+    if force:
+        arg.append('-force')
+    if not verbose:
+        arg.append('-quiet')
+    if not (nthreads is None):
+        arg.extend(['-nthreads', str(nthreads)])
+    arg.extend(['-no_bzero',
+                '-singleshell',
+                '-shell', str(shell),
+                input, output])
+    completion = subprocess.run(arg)
+    if completion.returncode != 0:
+        raise Exception('Unable to extract specified shells from DWI. '
+                        'See above for errors.')
+
+def extractmeanshell(input, output, shell, nthreads=None, force=False,
+              verbose=False):
+    """
+    Extracts mean of specified from an input mif file.
+
+    Parameters
+    ----------
+    input : str
+        Path to input .mif file
+    output : str
+        Path to output .mif file
+    shell : int
+        Approximate b-value to extract
+    nthreads : int, optional
+        Specify the number of threads to use in processing
+        (Default: all available threads)
+    force : bool, optional
+        Force overwrite of output files if pre-existing
+        (Default:False)
+    verbose : bool, optional
+        Specify whether to print console output (Default: False)
+
+    Returns
+    -------
+    None; writes out file
+    """
+    if not op.exists(input):
+        raise OSError('Input path does not exist. Please ensure that '
+                      'the folder or file specified exists.')
+    if not op.exists(op.dirname(output)):
+        raise OSError('Specifed directory for output file {} does not '
+                      'exist. Please ensure that this is a valid '
+                      'directory.'.format(op.dirname(output)))
+    if not isinstance(shell, int):
+        raise Exception('Please specify the shell to extract as an '
+                        'integer.')
+    if shell < 0:
+        raise Exception('Please specify the shell to extract as a '
+                        'positive (more than 0) integer.')
+    if not (nthreads is None):
+        if not isinstance(nthreads, int):
+            raise Exception('Please specify the number of threads as an '
+                            'integer.')
+    if not isinstance(force, bool):
+        raise Exception('Please specify whether forced overwrite is True '
+                        'or False.')
+    if not isinstance(verbose, bool):
+        raise Exception('Please specify whether verbose is True or False.')
+    outdir = op.dirname(output)
+    fname_shell = op.join(outdir, 'b' + str(shell) + '_ALL.mif')
+    fname_mean = op.join(outdir, 'b' + str(shell) + '_MEAN.mif')
+    # Extract all specified shells
+    extractshell(input, fname_shell, shell=shell, nthreads=nthreads,
+                 force=force, verbose=verbose)
+    # Compute mean
+    arg_mean = ['mrmath', '-axis', '3', fname_shell, 'mean', fname_mean]
+    completion = subprocess.run(arg_mean)
+    if completion.returncode != 0:
+        raise Exception('Unable to compute mean of B0s. See above for'
+                        'errors.')
+    arg_nan = ['mrcalc', fname_mean, '-finite', fname_mean,
+                '0', '-if', output]
+    completion = subprocess.run(arg_nan)
+    if completion.returncode != 0:
+        raise Exception('Unable to remove NaNs from averaged shell '
+                        'image. See above for errors.')
+    # Remove non-essential files
+    os.remove(fname_shell)
+    os.remove(fname_mean)
 
 def epiboost(input, output, num=1, nthreads=None, force=False,
               verbose=False):

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -169,9 +169,10 @@ def main():
     parser.add_argument('--user_mask', metavar='path',
                         help='Path to user-supplied brain mask.',
                         type=str)
-    parser.add_argument('-c', '--csf', action='store_true', default=False,
+    parser.add_argument('-cf', '--csf_fsl', action='store_true', default=False,
                         help='Compute a CSF mask for CSF-excluded '
-                        'smoothing to minimize partial volume effects.')
+                        'smoothing to minimize partial volume '
+                        'effects using FSL FAST.')
     parser.add_argument('--reslice', metavar='x,y,z',
                         help='Relices DWI to voxel resolution '
                         'specified in millimeters (mm) or output '
@@ -305,7 +306,6 @@ def main():
         args.smooth = True
         #--extra options--
         args.mask = True
-        args.csf = True
         args.degibbs = True
         args.rician = True
 
@@ -658,7 +658,7 @@ def main():
     #-----------------------------------------------------------------
     # Create CSF Mask
     #-----------------------------------------------------------------
-    if args.csf:
+    if args.csf_fsl:
         csfmask_name = 'csf_mask.nii'
         csfmask_out = op.join(outpath, csfmask_name)
         mrpreproc.csfmask(input=working_path,

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -309,7 +309,7 @@ def main():
         args.denoise = True
         args.undistort = True
         args.smooth = True
-        #--extra options--
+        args.csf_adc = 2
         args.mask = True
         args.degibbs = True
         args.rician = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = '2021, MUSC Advanced MRI Analysis (MAMA)'
 author = 'Siddhartha Dhiman, Joshua Teves, Kayti Keith'
 
 # The full version, including alpha/beta/rc tags
-release = 'v1.0-RC10'
+release = 'v1.0-RC11'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This PR introduces a way to smooth CSF and non-CSF tissues separately without propagation to minimize partial volume effect (PVE) arising from Gaussian filtering of voxels at the border.

Two methods have been currently introduced with one of them being default:

1. `-cf or --csf_fsl` using FSL FAST segmentation to derive a CSF mask
2. `-cd or csf_adc n` (default) using pseudo-ADC threshold of more than 2 (ADC > 2) to compute  a CSF mask. Pseudo-ADC is defined as `ln (S0/S1000) / (b1000/1000)` . This method is flexible and looks for b-value shells close to 1000.

We found the latter method (2) to be more conservative and produce better results with minimal alteration of DTI/DKI metric while minimize PVE.