### PR TITLE
Fix for SciPy cmake error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,13 +43,16 @@ RUN apt-get update && \
       software-properties-common \
       python2.7 python-pip \
       python3-pip \
-      jq
+      jq \
+      libblas-dev \
+      liblapack-dev \
+      libatlas-base-dev \
+      gfortran
 
 # Install MRTRIX3 dependencies
 RUN apt-get install -y --no-install-recommends \
       clang \
       git \
-      python-numpy \
       libeigen3-dev \
       zlib1g-dev \
       libqt4-opengl-dev \

--- a/docker/Dockerfile_develop
+++ b/docker/Dockerfile_develop
@@ -42,7 +42,11 @@ RUN apt-get update && \
       nano \
       software-properties-common \
       python2.7 python-pip \
-      python3-pip
+      python3-pip \
+      libblas-dev \
+      liblapack-dev \
+      libatlas-base-dev \
+      gfortran
 
 # Install MRTRIX3 dependencies
 RUN apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile_release
+++ b/docker/Dockerfile_release
@@ -42,13 +42,17 @@ RUN apt-get update && \
       nano \
       software-properties-common \
       python2.7 python-pip \
-      python3-pip
+      python3-pip \
+      libblas-dev \
+      liblapack-dev \
+      libatlas-base-dev \
+      gfortran
 
 # Install MRTRIX3 dependencies
 RUN apt-get install -y --no-install-recommends \
       clang \
       git \
-      python-numpy \
+      # python-numpy \
       libeigen3-dev \
       zlib1g-dev \
       libqt4-opengl-dev \


### PR DESCRIPTION
Fixes the following error during `docker build [IMAGE]`:

```
libraries mkl_rt not found
in [’/usr/local/lib’, ‘/usr/lib’, ‘/usr/lib/aarch64-linux-gnu’]
```