### PR TITLE
Fix logic in multi-TE protocol detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 # Files to ignore
 .DS_Store
 designer/._DESIGNER.py
+.nii

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,26 @@ Changelog
 All notable changes to this project will be documented in this file or
 page
 
+`v1.0-RC12`_
+------------
+
+Jan 14, 2022
+
+**Added**
+
+* None
+
+**Changed**
+
+* Fixed a logic in multi-TE detection algorithm that prevented certain
+  datasets from processing
+* Overhauled how inputs paths are entered. Paths to input DWIs can now
+  be provided to PyDesigner without comma separation
+
+**Removed**
+
+* None
+
 `v1.0-RC11`_
 ------------
 
@@ -74,7 +94,7 @@ Jun 29, 2021
 
 Mar 16, 2021
 
-**Added**:
+**Added**
 
 * None
 
@@ -92,7 +112,7 @@ Mar 16, 2021
 
 Feb 15, 2021
 
-**Added**:
+**Added**
 
 * Added missing Rician preprocessing to :code:`-s, --standard`
   preprocessing
@@ -111,7 +131,7 @@ Feb 15, 2021
 
 Feb 11, 2021
 
-**Added**:
+**Added**
 
 * Missing Docker figures in RTD documentation
 
@@ -131,7 +151,7 @@ Feb 11, 2021
 
 Dec 22, 2020
 
-**Added**:
+**Added**
 
 * None
 
@@ -157,7 +177,7 @@ Dec 22, 2020
 
 Oct 26, 2020
 
-**Added**:
+**Added**
 
 * Check for b-value scaling so .bval file so values
   specified as either 2.0 or 2000 can be processed.
@@ -168,7 +188,7 @@ Oct 26, 2020
   produces an ``fbi_tractography_dsi.fib`` file that can be loaded
   into DSI Studio to perform tractography.
 
-**Changed**:
+**Changed**
 
 * Fixed issue where eddy correction would attempt
   to QC and fail despite parsing the ``--noqc`` flag.
@@ -186,18 +206,18 @@ Oct 26, 2020
 
 Sep 22, 2020
 
-**Added**:
+**Added**
 
 * Reslicing compatibility udpated for new MRTrix3 version
   where ``mrrelice`` has been changed to ``mrgrid``.
   PyDesigner will work with either versions.
 
-**Changed**:
+**Changed**
 
 * Fixed a bad indent in tensor reordering function
   that produced an error in DTI protocols.
 
-**Removed**:
+**Removed**
 
 * None
 
@@ -206,7 +226,7 @@ Sep 22, 2020
 
 Sep 21, 2020
 
-**Added**:
+**Added**
 
 * FBI fODF map for FBI tractography. Users may use MRTrix3
   to further process this file.
@@ -216,11 +236,11 @@ Sep 21, 2020
   ``-l_max n`` flag. This is based on
   information found at https://mrtrix.readthedocs.io/en/dev/concepts/sh_basis_lmax.html
 
-**Changed**:
+**Changed**
 
 * None
 
-**Removed**:
+**Removed**
 
 * None
 
@@ -229,11 +249,11 @@ Sep 21, 2020
 
 Aug 25, 2020
 
-**Added**:
+**Added**
 
 * References to README.rst
 
-**Changed**:
+**Changed**
 
 * The minimum B-value required for FBI (4000) is now inclusive
   instead of exclusive. This would allow executiong of FBI/FBWM
@@ -242,7 +262,7 @@ Aug 25, 2020
   can recognize the flag
 * Updated Slack permalink in README.rst
 
-**Removed**:
+**Removed**
 
 * None
 
@@ -251,7 +271,7 @@ Aug 25, 2020
 
 Aug 19, 2020
 
-**Added**:
+**Added**
 
 * Methods to perform tensor only with compatible B-values. PyDesigner
   previously use all B-values in a DWI to do so. This behavior has
@@ -259,13 +279,13 @@ Aug 19, 2020
 * FBI and FBWM calculations
 * Brief documentation on how to run PyDesigner
 
-**Changed**:
+**Changed**
 
 * Automatically issues ``dwipreproc`` or ``dwifslpreproc`` for
   compatibility with MRtrix3 >= 3.0.1
 * Updated minimum version for required Python modules
 
-**Removed**:
+**Removed**
 
 * None
 
@@ -274,12 +294,12 @@ Aug 19, 2020
 
 Apr 21, 2020
 
-**Added**:
+**Added**
 
 * Intrinsic inter-axonal and mean extra-axonal diffusivity
   calculation to WMTI
 
-**Changed**:
+**Changed**
 
 * Method ``json2fslgrad`` converted from class method to function
   definition
@@ -290,7 +310,7 @@ Apr 21, 2020
 * DKE conversion scripts modified to correctly create ft and dke
   parameter files
 
-**Removed**:
+**Removed**
 
 * None
 
@@ -299,18 +319,18 @@ Apr 21, 2020
 
 Apr 9, 2020
 
-**Added**:
+**Added**
 
 * NaN check in AWF calculculation that prevents further errors in intra-axonal
   and extra-axonal WMTI metrics computation
 
-**Changed**:
+**Changed**
 
 * ``designer.fitting.dwipy`` input file detection method
 * ``Dockerfile_release`` now deletes the correct temporary file to prevent build
   error
 
-**Removed**:
+**Removed**
 
 * None
 
@@ -319,14 +339,14 @@ Apr 9, 2020
 
 Apr 8, 2020
 
-**Added**:
+**Added**
 
 * Head motion plot from on eddy_qc outputs
 * Outlier plot from IRRLS outlier detection
 * Updated documentation
 * Option to reslice DWI with ``--reslice [x,y,z]``
 
-**Changed**:
+**Changed**
 
 * Flag ``--epiboost [index]`` changed to ``--epi [n]``, where
   users can specify the number of reverse phase encoded B0 pairs to
@@ -340,7 +360,7 @@ Apr 8, 2020
   that gets called by PyDesigner main. This allows a B0.nii to be
   produced regardless of the ``--mask`` flag.
 
-**Removed**:
+**Removed**
 
 * Documentation inconsistencies
 
@@ -349,7 +369,7 @@ Apr 8, 2020
 
 Feb 26, 2020
 
-**Added**:
+**Added**
 
 * Installer for setup with ``pip install .``
 * Multiple file support: *.nii*, *.nii.gz*, *.dcm*, *.mif*
@@ -359,11 +379,11 @@ Feb 26, 2020
 * Full utilization of AVX instruction set on AMD machines
 * WMTI parameters
 
-**Changed**:
+**Changed**
 
 * Fixed topup series not being denoised
 
-**Removed**:
+**Removed**
 
 * CSF masking; feature failed to work consistently
 
@@ -373,16 +393,16 @@ Feb 26, 2020
 Dec 2, 2019
 
 
-**Added**:
+**Added**
 
 * None
 
-**Changed**:
+**Changed**
 
 * Fixed bug in Dockerfile that prevented ``pydesigner.py`` from being
   found
 
-**Removed**:
+**Removed**
 
 * None
 
@@ -396,6 +416,7 @@ Initial port of MATLAB code to Python. 200,000,000,000 BCE
 
 .. Links
 
+.. _v1.0-RC12: https://github.com/m-ama/PyDesigner/releases/tag/v1.0-RC12
 .. _v1.0-RC11: https://github.com/m-ama/PyDesigner/releases/tag/v1.0-RC11
 .. _v1.0-RC10: https://github.com/m-ama/PyDesigner/releases/tag/v1.0-RC10
 .. _v1.0-RC9: https://github.com/m-ama/PyDesigner/releases/tag/v1.0-RC9

--- a/designer/info.py
+++ b/designer/info.py
@@ -10,7 +10,7 @@ __execdir__ = os.path.basename(
     )
 )
 __packagename__ = 'PyDesigner'
-__version__='v1.0-RC11'
+__version__='v1.0-RC12'
 __author__ = 'PyDesigner developers'
 __copyright__ = 'Copyright 2021, PyDesigner developers, MUSC Advanced Image Analysis (MAMA)'
 __credits__ = [

--- a/designer/preprocessing/util.py
+++ b/designer/preprocessing/util.py
@@ -355,7 +355,7 @@ class DWIParser:
         self : class
             DWIParser class object
         """
-        UserCpath = path.rsplit(',')
+        UserCpath = path
         self.DWIlist = [op.realpath(i) for i in UserCpath]
         # This loop determines the types of inputs parsed into the function
         ftype = []

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -177,18 +177,18 @@ def main():
                         help='Compute a CSF mask for CSF-excluded '
                         'smoothing to minimize partial volume '
                         'effects using thresholding a pseudo-ADC map '
-                        'computed as ln(S0/S1000)/b1000.')
+                        'computed as ln(S0/S1000)/b1000. Default: 2')
     parser.add_argument('--reslice', metavar='x,y,z',
                         help='Relices DWI to voxel resolution '
                         'specified in millimeters (mm) or output '
                         'dimensions. Performing reslicing will skip '
                         'plotting of SNR curves. Providing dimensions '
-                        'greater than 9 will swtich from mm voxel '
+                        'greater than 9 will switch from mm voxel '
                         'reslicing to output image reslicing.')
     parser.add_argument('--interp', action='store_true', default='linear',
                         help='Set the interpolation to use when '
                         'reslicing. Choices are linear (default), ' 
-                        'nearest, cubic, sinc.')
+                        'nearest, cubic, and sinc.')
     parser.add_argument('-te', '--multite', action='store_true',
                         default=False,
                         help='Specify whether input DWI consists of '

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -107,8 +107,9 @@ def main():
 
     # Mandatory
     parser.add_argument('dwi',
-                        help='the diffusion dataset you would like '
-                        'to process',
+                        nargs='+',
+                        help='The diffusion dataset you would like '
+                        'to process. ',
                         type=str)
 
     # Optional

--- a/designer/pydesigner.py
+++ b/designer/pydesigner.py
@@ -882,7 +882,7 @@ def main():
     # Handle multi-echo data
     #-----------------------------------------------------------------
     imPath = filetable['HEAD'].getFull()
-    if multi_echo:
+    if multi_echo and args.multite:
         imPath = []
         for i in range(len(image.echotime)):
             echo_out = op.join(outpath, 'TE' + str(image.echotime[i]) + '_dwi_preprocessed.nii')

--- a/docs/source/docker/docker_neurodock.rst
+++ b/docs/source/docker/docker_neurodock.rst
@@ -29,11 +29,11 @@ following command to pull NeuroDock.
     $ docker pull docker pull dmri/neurodock:tagname
 
 where :code:`tagname` is the version you'd like to pull. To install
-NeuroDock v0.2, you would run the command
+the latest NeuroDock, you would run the command
 
 .. code-block:: console
 
-    $ docker pull dmri/neurodock:v0.2
+    $ docker pull dmri/neurodock:latest
 
 And that's it! All you have to do now is to wait for the NeuroDock
 image to finish downloading.

--- a/docs/source/reference/pydesigner_args.rst
+++ b/docs/source/reference/pydesigner_args.rst
@@ -22,35 +22,40 @@ Preprocessing contol flags allow users to tweak certain parts of the
 preprocessing pipeline, to accomodate all types of datasets.
 
 
--s, --standard  Runs the recommended preprocessing pipeline in order: denoise, degibbs, undistort, brain mask, smooth, rician
+-s, --standard      Runs the recommended preprocessing pipeline in order: denoise, degibbs, undistort, brain mask, smooth, rician
 
 -n, --denoise       Denoises input DWI
 
---extent        Shape of denoising extent matrix, defaults to 5,5,5
+--extent            Shape of denoising extent matrix, defaults to 5,5,5
 
---reslice       Reslices input DWI and outputs to a specific resolution in mm or output dimensions
+--reslice xyz       Reslices DWI to voxel resolution specified in miliimeters (mm) or output dimensions. Performinh reslicing will skip plotting of SNR curves. Dimensions less than 9 will reslice in mm, image dimension otherwise. Specify argument as `--reslice x,y,z`.
 
---interp        The interpolation method to use when resizing
+--interp CHOICE     Set the interpolation to use when reslicing. Choices are linear (default), nearest, cubic, and sinc
 
 -g, --degibbs       Corrects Gibb’s ringing
 
 -u, --undistort     Undistorts image using a suite of EPI distortion correction, eddy current correction, and co-registration. Does not run EPI correction if reverse phase encoding DWI is absent.
 
---rpe_pairs n   Speeds up topup if a reverse PE is present; specify the number (integer) of reverse PE direction B0 pairs to use
+--rpe_pairs N       Speeds up TOPUP if a reverse PE is present; specify the number (integer) of reverse PE direction B0 pairs to use.
 
---mask          Computes a brain mask at 0.20 threshold by default
+--mask              Computes a brain mask at 0.20 threshold by default
 
---maskthr       Specify FSL bet fractional intensity threshold for brain masking, defaults to 0.20
+--maskthr           Specify FSL bet fractional intensity threshold for brain masking, defaults to 0.20
 
---user_mask     Provide path to user-generated brain mask in NifTi (.nii) format
+--user_mask         Provide path to user-generated brain mask in NifTi (.nii) format
+
+-cf, --csf_fsl      Compute a CSF mask for CSF-excluded smoothing to minimize partial volume effects using FSL fit_constraints
+
+-cd, --csf_adc  Compute CSF mask for CSF-excluded smoothing to minimize partial volume effects by thresholding a pseudo-ADC map computed as ln(S0/S1000)/b1000. N is the ADC thresold to use (default: 2).
 
 -z, --smooth        Smooths DWI data at a default FWHM of 1.25
 
---fwhm          Specify the FWHM at which to smooth, defaults to 1.25
+--fwhm              Specify the FWHM at which to smooth, defaults to 1.25
 
 -r, --rician        Corrects Rician bias
 
--te             Enable multi-TE support. This mode preprocesses all concatenated DWIs together, but performs tensor fitting separately.
+-te, --multite      Enable multi-TE support. This mode preprocesses all concatenated DWIs together, but performs tensor fitting separately.
+
 
 Diffusion Tensor Control
 ------------------------

--- a/docs/source/reference/pydesigner_files.rst
+++ b/docs/source/reference/pydesigner_files.rst
@@ -29,6 +29,10 @@ The list of ever possible output file is given in the table below.
 | :code:`brain_mask.nii`              | brain mask extracted from B0.nii (exists only if         |
 |                                     | :code:`--mask` is used)                                  |
 +-------------------------------------+----------------------------------------------------------+
+|                                     |                                                          |
+| :code:`csf_mask.nii`                | csf mask extracted from B0.nii (exists only if           |
+|                                     | :code:`---cf` or :code:`---cd`are used)                  |
++-------------------------------------+----------------------------------------------------------+
 | :code:`dwi_preprocessed.nii`        | fully preprocessed DWI NifTi file                        |
 +-------------------------------------+----------------------------------------------------------+
 | :code:`dwi_preprocessed.bval`       | fully preprocessed DWI's BVAL file in FSL format         |


### PR DESCRIPTION
Fixes a logic in acquisitions containing multiple echo times (TE). This fix closes #277 and #279, where user had a reverse phase encoded image with a slightly different TE.

Documentation has also been updated to reflect new files and flags.